### PR TITLE
refactor: Member를 제외한 모든 Controller-Service 내 tokenProvider 위치 수정

### DIFF
--- a/server/src/main/java/com/codecozy/server/controller/BookController.java
+++ b/server/src/main/java/com/codecozy/server/controller/BookController.java
@@ -2,6 +2,7 @@ package com.codecozy.server.controller;
 
 import com.codecozy.server.dto.request.*;
 import com.codecozy.server.dto.response.GetReadingNoteResponse;
+import com.codecozy.server.security.TokenProvider;
 import com.codecozy.server.service.BookService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,221 +14,327 @@ import java.util.Map;
 @RequestMapping("/book")
 @RequiredArgsConstructor
 public class BookController {
+    private final TokenProvider tokenProvider;
     private final BookService bookService;
 
     // 책 등록 API
     @PostMapping("/create/{isbn}")
-    public ResponseEntity createBook(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody ReadingBookCreateRequest request) {
-        return bookService.createBook(token, isbn, request);
+    public ResponseEntity createBook(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                     @RequestBody ReadingBookCreateRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.createBook(memberId, isbn, request);
     }
 
     // 책 삭제 API
     @DeleteMapping("/delete/{isbn}")
     public ResponseEntity deleteBook(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
-        return bookService.deleteBook(token, isbn);
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.deleteBook(memberId, isbn);
     }
 
     // 책별 독서노트 조회 API
     @GetMapping("/readingNote")
     public ResponseEntity getReadingNote(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
-        return bookService.getReadingNote(token, isbn);
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.getReadingNote(memberId, isbn);
     }
 
     // 독서상태 변경 API
     @PatchMapping("/readingStatus/{isbn}")
-    public ResponseEntity modifyReadingStatus(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody Map<String, Integer> readingStatusMap) {
-        return bookService.modifyReadingStatus(token, isbn, readingStatusMap.get("readingStatus"));
+    public ResponseEntity modifyReadingStatus(@RequestHeader("xAuthToken") String token,
+                                              @PathVariable("isbn") String isbn,
+                                              @RequestBody Map<String, Integer> readingStatusMap) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyReadingStatus(memberId, isbn, readingStatusMap.get("readingStatus"));
     }
 
     // 소장여부 변경 API
     @PatchMapping("/isMine/{isbn}")
-    public ResponseEntity modifyIsMine(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody Map<String, Boolean> isMineMap) {
-        return bookService.modifyIsMine(token, isbn, isMineMap.get("isMine"));
+    public ResponseEntity modifyIsMine(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                       @RequestBody Map<String, Boolean> isMineMap) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyIsMine(memberId, isbn, isMineMap.get("isMine"));
     }
 
     // 책 유형 변경 API
     @PatchMapping("/bookType/{isbn}")
-    public ResponseEntity modifyBookType(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody Map<String, Integer> bookTypeMap) {
-        return bookService.modifyBookType(token, isbn, bookTypeMap.get("bookType"));
+    public ResponseEntity modifyBookType(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                         @RequestBody Map<String, Integer> bookTypeMap) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyBookType(memberId, isbn, bookTypeMap.get("bookType"));
     }
 
     // 읽은 페이지 변경 API
     @PatchMapping("/page/{isbn}")
-    public ResponseEntity modifyReadingPage(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody ModifyPageRequest request) {
-        return bookService.modifyReadingPage(token, isbn, request);
+    public ResponseEntity modifyReadingPage(@RequestHeader("xAuthToken") String token,
+                                            @PathVariable("isbn") String isbn, @RequestBody ModifyPageRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyReadingPage(memberId, isbn, request);
     }
 
     // 리뷰 작성 API
     @PostMapping("/review/{isbn}")
-    public ResponseEntity createReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody ReviewCreateRequest request) {
-        return bookService.createReview(token, isbn, request);
+    public ResponseEntity createReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                       @RequestBody ReviewCreateRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.createReview(memberId, isbn, request);
     }
 
     // 리뷰 전체 수정 API
     @PatchMapping("/modifyReview/{isbn}")
-    public ResponseEntity modifyReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody ReviewCreateRequest request) {
-        return bookService.modifyReview(token, isbn, request);
+    public ResponseEntity modifyReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                       @RequestBody ReviewCreateRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyReview(memberId, isbn, request);
     }
 
     // 리뷰 전체 삭제 API
     @DeleteMapping("/deleteReview/{isbn}")
     public ResponseEntity deleteReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
-        return bookService.deleteReview(token, isbn);
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.deleteReview(memberId, isbn);
     }
 
     // 한줄평 삭제 API
     @DeleteMapping("/deleteComment/{isbn}")
     public ResponseEntity deleteComment(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
-        return bookService.deleteComment(token, isbn);
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.deleteComment(memberId, isbn);
     }
 
     // 한줄평 반응 추가 API
     @PostMapping("/reaction/{isbn}")
-    public ResponseEntity reactionComment(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody CommentReactionRequest request) {
-        return bookService.reactionComment(token, isbn, request);
+    public ResponseEntity reactionComment(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                          @RequestBody CommentReactionRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.reactionComment(memberId, isbn, request);
     }
 
     // 한줄평 반응 수정 API
     @PatchMapping("/modifyReaction/{isbn}")
-    public ResponseEntity modifyReaction(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody CommentReactionRequest request) {
-        return bookService.modifyReaction(token, isbn, request);
+    public ResponseEntity modifyReaction(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                         @RequestBody CommentReactionRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyReaction(memberId, isbn, request);
     }
 
     // 한줄평 반응 삭제 API
     @DeleteMapping("/deleteReaction/{isbn}")
-    public ResponseEntity deleteReaction(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody DeleteReactionRequest request) {
-        return bookService.deleteReaction(token, isbn, request);
+    public ResponseEntity deleteReaction(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                         @RequestBody DeleteReactionRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.deleteReaction(memberId, isbn, request);
     }
 
     // 신고하기 API
     @PostMapping("/report/{isbn}")
-    public ResponseEntity reportComment(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody ReportCommentRequest request) {
-        return bookService.reportComment(token, isbn, request);
+    public ResponseEntity reportComment(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                        @RequestBody ReportCommentRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.reportComment(memberId, isbn, request);
     }
 
     // 읽고싶은 책 등록 API
     @PostMapping("/wantToRead/{isbn}")
-    public ResponseEntity wantToRead(@RequestHeader ("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody BookCreateRequest request) {
-        return bookService.wantToRead(token, isbn, request);
+    public ResponseEntity wantToRead(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                     @RequestBody BookCreateRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.wantToRead(memberId, isbn, request);
     }
 
     // 읽기 시작한 날짜 변경 API
     @PatchMapping("/modifyStartDate/{isbn}")
-    public ResponseEntity modifyStartDate(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody Map<String, String> startDateMap) {
-        return bookService.modifyStartDate(token, isbn, startDateMap.get("startDate"));
+    public ResponseEntity modifyStartDate(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                          @RequestBody Map<String, String> startDateMap) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyStartDate(memberId, isbn, startDateMap.get("startDate"));
     }
 
     // 마지막 읽은 날짜 변경 API
     @PatchMapping("/modifyRecentDate/{isbn}")
-    public ResponseEntity modifyRecentDate(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody Map<String, String> recentDateMap) {
-        return bookService.modifyRecentDate(token, isbn, recentDateMap.get("recentDate"));
+    public ResponseEntity modifyRecentDate(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                           @RequestBody Map<String, String> recentDateMap) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyRecentDate(memberId, isbn, recentDateMap.get("recentDate"));
     }
 
     // 책별 대표 위치 등록 API
     @PostMapping("/mainLocation/{isbn}")
-    public ResponseEntity addMainLocation(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody LocationRequest request) {
-        return bookService.addMainLocation(token, isbn, request);
+    public ResponseEntity addMainLocation(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                          @RequestBody LocationRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.addMainLocation(memberId, isbn, request);
     }
 
     // 책별 대표 위치 변경 API
     @PatchMapping("/modifyMainLocation/{isbn}")
-    public ResponseEntity modifyMainLocation(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody LocationRequest request) {
-        return bookService.modifyMainLocation(token, isbn, request);
+    public ResponseEntity modifyMainLocation(@RequestHeader("xAuthToken") String token,
+                                             @PathVariable("isbn") String isbn, @RequestBody LocationRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyMainLocation(memberId, isbn, request);
     }
 
     // 책별 대표 위치 삭제 API
     @DeleteMapping("/deleteMainLocation/{isbn}")
-    public ResponseEntity deleteMainLocation(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
-        return bookService.deleteMainLocation(token, isbn);
+    public ResponseEntity deleteMainLocation(@RequestHeader("xAuthToken") String token,
+                                             @PathVariable("isbn") String isbn) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.deleteMainLocation(memberId, isbn);
     }
 
     // 인물사전 등록 API
     @PostMapping("/personalDictionary/{isbn}")
-    public ResponseEntity addpersonalDictionary(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody PersonalDictionaryRequest request) {
-        return bookService.addpersonalDictionary(token, isbn, request);
+    public ResponseEntity addpersonalDictionary(@RequestHeader("xAuthToken") String token,
+                                                @PathVariable("isbn") String isbn,
+                                                @RequestBody PersonalDictionaryRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.addpersonalDictionary(memberId, isbn, request);
     }
 
     // 인물사전 수정 API
     @PatchMapping("/modifyPersonalDictionary/{isbn}")
-    public ResponseEntity modifyPersonalDictionary(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody PersonalDictionaryRequest request) {
-        return bookService.modifyPersonalDictionary(token, isbn, request);
+    public ResponseEntity modifyPersonalDictionary(@RequestHeader("xAuthToken") String token,
+                                                   @PathVariable("isbn") String isbn,
+                                                   @RequestBody PersonalDictionaryRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyPersonalDictionary(memberId, isbn, request);
     }
 
     // 인물사전 삭제 API
     @DeleteMapping("/deletePersonalDictionary/{isbn}")
-    public ResponseEntity deletePersonalDictionary(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody DeletePersonalDictionaryRequest request) {
-        return bookService.deletePersonalDictionary(token, isbn, request);
+    public ResponseEntity deletePersonalDictionary(@RequestHeader("xAuthToken") String token,
+                                                   @PathVariable("isbn") String isbn,
+                                                   @RequestBody DeletePersonalDictionaryRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.deletePersonalDictionary(memberId, isbn, request);
     }
 
     // 인물사전 전체조회 API
     @GetMapping("/getPersonalDictionary/{isbn}")
-    public ResponseEntity getPersonalDictionary(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
-        return bookService.getPersonalDictionary(token, isbn);
+    public ResponseEntity getPersonalDictionary(@RequestHeader("xAuthToken") String token,
+                                                @PathVariable("isbn") String isbn) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.getPersonalDictionary(memberId, isbn);
     }
 
     // 메모 등록 API
     @PostMapping("/memo/{isbn}")
-    public ResponseEntity addMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody MemoRequest request) {
-        return bookService.addMemo(token, isbn, request);
+    public ResponseEntity addMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                  @RequestBody MemoRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.addMemo(memberId, isbn, request);
     }
 
     // 메모 수정 API
     @PatchMapping("/modifyMemo/{isbn}")
-    public ResponseEntity modifyMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody MemoRequest request) {
-        return bookService.modifyMemo(token, isbn, request);
+    public ResponseEntity modifyMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                     @RequestBody MemoRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyMemo(memberId, isbn, request);
     }
 
     // 메모 삭제 API
     @DeleteMapping("/deleteMemo/{isbn}")
-    public ResponseEntity deleteMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody DeleteUuidRequest request) {
-        return bookService.deleteMemo(token, isbn, request);
+    public ResponseEntity deleteMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                     @RequestBody DeleteUuidRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.deleteMemo(memberId, isbn, request);
     }
 
     // 메모 전체조회 API
     @GetMapping("/getMemo/{isbn}")
     public ResponseEntity getMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
-        return bookService.getMemo(token, isbn);
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.getMemo(memberId, isbn);
     }
 
     // 책갈피 등록 API
     @PostMapping("/bookmark/{isbn}")
-    public ResponseEntity addBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody BookmarkRequest request) {
-        return bookService.addBookmark(token, isbn, request);
+    public ResponseEntity addBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                      @RequestBody BookmarkRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.addBookmark(memberId, isbn, request);
     }
 
     // 책갈피 수정 API
     @PatchMapping("/modifyBookmark/{isbn}")
-    public ResponseEntity modifyBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody BookmarkRequest request) {
-        return bookService.modifyBookmark(token, isbn, request);
+    public ResponseEntity modifyBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                         @RequestBody BookmarkRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.modifyBookmark(memberId, isbn, request);
     }
 
     // 책갈피 삭제 API
     @DeleteMapping("/deleteBookmark/{isbn}")
-    public ResponseEntity deleteBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn, @RequestBody DeleteUuidRequest request) {
-        return bookService.deleteBookmark(token, isbn, request);
+    public ResponseEntity deleteBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
+                                         @RequestBody DeleteUuidRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.deleteBookmark(memberId, isbn, request);
     }
 
     // 책갈피 전체조회 API
     @GetMapping("/getBookmark/{isbn}")
-    public  ResponseEntity getBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
-        return  bookService.getBookmark(token, isbn);
+    public ResponseEntity getBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.getBookmark(memberId, isbn);
     }
 
     // 전체 위치 조회 API
     @GetMapping("/getAllLocation")
-    public ResponseEntity getAllLocation(@RequestHeader("xAuthToken") String token, @RequestBody GetAllLocationRequest request) {
-        return bookService.getAllLocation(token, request);
+    public ResponseEntity getAllLocation(@RequestHeader("xAuthToken") String token,
+                                         @RequestBody GetAllLocationRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.getAllLocation(memberId, request);
     }
 
     // 최근 등록 위치 조회 API
     @GetMapping("/getRecentLocation")
     public ResponseEntity getRecentLocation(@RequestHeader("xAuthToken") String token) {
-        return bookService.getRecentLocation(token);
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.getRecentLocation(memberId);
     }
 
     // 최근 등록 위치 삭제 API
     @DeleteMapping("/deleteRecentLocation")
-    public ResponseEntity deleteRecentLocation(@RequestHeader("xAuthToken") String token, @RequestBody DeleteRecentLocationRequest request) {
-        return bookService.deleteRecentLocation(token, request);
+    public ResponseEntity deleteRecentLocation(@RequestHeader("xAuthToken") String token,
+                                               @RequestBody DeleteRecentLocationRequest request) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookService.deleteRecentLocation(memberId, request);
     }
 }

--- a/server/src/main/java/com/codecozy/server/controller/BookshelfController.java
+++ b/server/src/main/java/com/codecozy/server/controller/BookshelfController.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.controller;
 
+import com.codecozy.server.security.TokenProvider;
 import com.codecozy.server.service.BookshelfService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,19 +14,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/bookshelf")
 @RequiredArgsConstructor
 public class BookshelfController {
+    private final TokenProvider tokenProvider;
     private final BookshelfService bookshelfService;
 
     // 책장 초기 조회
     @GetMapping("/{bookshelfType}")
     public ResponseEntity getAllBookshelf(@RequestHeader("xAuthToken") String token,
                                           @PathVariable("bookshelfType") int bookshelfType) {
-        return bookshelfService.getAllBookshelf(token, bookshelfType);
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookshelfService.getAllBookshelf(memberId, bookshelfType);
     }
 
     // 책장 리스트용 조회
     @GetMapping("/detail/{bookshelfCode}")
     public ResponseEntity getDetailBookshelf(@RequestHeader("xAuthToken") String token,
                                              @PathVariable("bookshelfCode") String bookshelfCode) {
-        return bookshelfService.getDetailBookshelf(token, bookshelfCode);
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return bookshelfService.getDetailBookshelf(memberId, bookshelfCode);
     }
 }

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -34,9 +34,8 @@ public class BookService {
     private final TokenProvider tokenProvider;
 
     // 사용자가 독서노트 추가 시 실행 (책 등록, 위치 등록, 독서노트 등록, 최근 검색 위치 등록)
-    public ResponseEntity<DefaultResponse> createBook(String token, String isbn, ReadingBookCreateRequest request) {
+    public ResponseEntity<DefaultResponse> createBook(Long memberId, String isbn, ReadingBookCreateRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 책 검색
@@ -99,9 +98,8 @@ public class BookService {
     }
 
     // 독서노트 삭제
-    public ResponseEntity<DefaultResponse> deleteBook(String token, String isbn) {
+    public ResponseEntity<DefaultResponse> deleteBook(Long memberId, String isbn) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 해당 책 찾기
@@ -117,9 +115,8 @@ public class BookService {
     }
 
     // 독서노트 조회
-    public ResponseEntity<DefaultResponse> getReadingNote(String token, String isbn) {
+    public ResponseEntity<DefaultResponse> getReadingNote(Long memberId, String isbn) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 해당 책 찾기
@@ -212,9 +209,8 @@ public class BookService {
     }
 
     // 독서상태 변경
-    public ResponseEntity<DefaultResponse> modifyReadingStatus(String token, String isbn, int readingStatus) {
+    public ResponseEntity<DefaultResponse> modifyReadingStatus(Long memberId, String isbn, int readingStatus) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 해당 책 찾기
@@ -231,9 +227,8 @@ public class BookService {
     }
 
     // 소장 여부 변경
-    public ResponseEntity<DefaultResponse> modifyIsMine(String token, String isbn, boolean isMine) {
+    public ResponseEntity<DefaultResponse> modifyIsMine(Long memberId, String isbn, boolean isMine) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 해당 책 찾기
@@ -250,9 +245,8 @@ public class BookService {
     }
 
     // 책 유형 변경
-    public ResponseEntity<DefaultResponse> modifyBookType(String token, String isbn, int bookType) {
+    public ResponseEntity<DefaultResponse> modifyBookType(Long memberId, String isbn, int bookType) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 해당 책 찾기
@@ -269,9 +263,8 @@ public class BookService {
     }
 
     // 읽은 페이지 변경
-    public ResponseEntity<DefaultResponse> modifyReadingPage(String token, String isbn, ModifyPageRequest request) {
+    public ResponseEntity<DefaultResponse> modifyReadingPage(Long memberId, String isbn, ModifyPageRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 해당 책 찾기
@@ -298,9 +291,8 @@ public class BookService {
     }
 
     // 한줄평 신고
-    public ResponseEntity<DefaultResponse> reportComment(String token, String isbn, ReportCommentRequest request) {
+    public ResponseEntity<DefaultResponse> reportComment(Long memberId, String isbn, ReportCommentRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 사용자 닉네임으로 한줄평 남긴 사용자 찾기
@@ -350,9 +342,8 @@ public class BookService {
     }
 
     // 읽고싶은 책 등록
-    public ResponseEntity<DefaultResponse> wantToRead(String token, String isbn, BookCreateRequest request) {
+    public ResponseEntity<DefaultResponse> wantToRead(Long memberId, String isbn, BookCreateRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 책 검색
@@ -380,9 +371,8 @@ public class BookService {
 
 
     // 한줄평 반응 추가
-    public ResponseEntity<DefaultResponse> reactionComment(String token, String isbn, CommentReactionRequest request) {
+    public ResponseEntity<DefaultResponse> reactionComment(Long memberId, String isbn, CommentReactionRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 사용자 닉네임으로 한줄평 남긴 사용자 찾기
@@ -436,9 +426,8 @@ public class BookService {
     }
 
     // 한줄평 반응 수정
-    public ResponseEntity<DefaultResponse> modifyReaction(String token, String isbn, CommentReactionRequest request) {
+    public ResponseEntity<DefaultResponse> modifyReaction(Long memberId, String isbn, CommentReactionRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 사용자 닉네임으로 한줄평 남긴 사용자 찾기
@@ -487,9 +476,8 @@ public class BookService {
     }
 
     // 한줄평 반응 삭제
-    public ResponseEntity<DefaultResponse> deleteReaction(String token, String isbn, DeleteReactionRequest request) {
+    public ResponseEntity<DefaultResponse> deleteReaction(Long memberId, String isbn, DeleteReactionRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 사용자 닉네임으로 한줄평 남긴 사용자 찾기
@@ -541,9 +529,8 @@ public class BookService {
     }
 
     // 리뷰 작성 (키워드, 선택 리뷰, 한줄평 각 테이블에 추가)
-    public ResponseEntity<DefaultResponse> createReview(String token, String isbn, ReviewCreateRequest request) {
+    public ResponseEntity<DefaultResponse> createReview(Long memberId, String isbn, ReviewCreateRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -593,9 +580,8 @@ public class BookService {
     }
 
     // 리뷰 전체 수정 (키워드, 선택 리뷰, 한줄평)
-    public ResponseEntity<DefaultResponse> modifyReview(String token, String isbn, ReviewCreateRequest request) {
+    public ResponseEntity<DefaultResponse> modifyReview(Long memberId, String isbn, ReviewCreateRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -659,9 +645,8 @@ public class BookService {
     }
 
     // 리뷰 전체 삭제 (키워드, 선택 리뷰, 한줄평)
-    public ResponseEntity<DefaultResponse> deleteReview(String token, String isbn) {
+    public ResponseEntity<DefaultResponse> deleteReview(Long memberId, String isbn) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -703,9 +688,8 @@ public class BookService {
     }
 
     // 한줄평 삭제
-    public ResponseEntity<DefaultResponse> deleteComment(String token, String isbn) {
+    public ResponseEntity<DefaultResponse> deleteComment(Long memberId, String isbn) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -738,9 +722,8 @@ public class BookService {
     }
 
     // 읽기 시작한 날짜 변경
-    public ResponseEntity<DefaultResponse> modifyStartDate(String token, String isbn, String startDate) {
+    public ResponseEntity<DefaultResponse> modifyStartDate(Long memberId, String isbn, String startDate) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -762,9 +745,8 @@ public class BookService {
     }
 
     // 마지막 읽은 날짜 (최근 날짜) 변경
-    public ResponseEntity<DefaultResponse> modifyRecentDate(String token, String isbn, String recentDate) {
+    public ResponseEntity<DefaultResponse> modifyRecentDate(Long memberId, String isbn, String recentDate) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -786,9 +768,8 @@ public class BookService {
     }
 
     // 책별 대표 위치 등록 (주소 테이블에 추가, 해당 책에 대표 위치 등록)
-    public ResponseEntity<DefaultResponse> addMainLocation(String token, String isbn, LocationRequest request) {
+    public ResponseEntity<DefaultResponse> addMainLocation(Long memberId, String isbn, LocationRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -841,9 +822,8 @@ public class BookService {
     }
 
     // 책별 대표 위치 변경
-    public ResponseEntity<DefaultResponse> modifyMainLocation(String token, String isbn, LocationRequest request) {
+    public ResponseEntity<DefaultResponse> modifyMainLocation(Long memberId, String isbn, LocationRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -902,9 +882,8 @@ public class BookService {
     }
 
     // 책별 대표 위치 삭제
-    public ResponseEntity<DefaultResponse> deleteMainLocation(String token, String isbn) {
+    public ResponseEntity<DefaultResponse> deleteMainLocation(Long memberId, String isbn) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -937,9 +916,8 @@ public class BookService {
     }
 
     // 인물사전 등록
-    public ResponseEntity<DefaultResponse> addpersonalDictionary(String token, String isbn, PersonalDictionaryRequest request) {
+    public ResponseEntity<DefaultResponse> addpersonalDictionary(Long memberId, String isbn, PersonalDictionaryRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -965,9 +943,8 @@ public class BookService {
     }
 
     // 인물사전 수정
-    public ResponseEntity<DefaultResponse> modifyPersonalDictionary(String token, String isbn, PersonalDictionaryRequest request) {
+    public ResponseEntity<DefaultResponse> modifyPersonalDictionary(Long memberId, String isbn, PersonalDictionaryRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -993,9 +970,8 @@ public class BookService {
     }
 
     // 인물사전 삭제
-    public ResponseEntity<DefaultResponse> deletePersonalDictionary(String token, String isbn, DeletePersonalDictionaryRequest request) {
+    public ResponseEntity<DefaultResponse> deletePersonalDictionary(Long memberId, String isbn, DeletePersonalDictionaryRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -1015,12 +991,11 @@ public class BookService {
     }
 
     // 인물사전 전체조회
-    public ResponseEntity<DefaultResponse> getPersonalDictionary(String token, String isbn) {
+    public ResponseEntity<DefaultResponse> getPersonalDictionary(Long memberId, String isbn) {
         // 응답으로 보낼 인물사전 List
         List<GetPersonalDictionaryResponse> personalDictionaryList = new ArrayList<>();
 
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -1041,9 +1016,8 @@ public class BookService {
     }
 
     // 메모 등록
-    public ResponseEntity<DefaultResponse> addMemo(String token, String isbn, MemoRequest request) {
+    public ResponseEntity<DefaultResponse> addMemo(Long memberId, String isbn, MemoRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -1064,9 +1038,8 @@ public class BookService {
     }
 
     // 메모 수정
-    public ResponseEntity<DefaultResponse> modifyMemo(String token, String isbn, MemoRequest request) {
+    public ResponseEntity<DefaultResponse> modifyMemo(Long memberId, String isbn, MemoRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -1089,9 +1062,8 @@ public class BookService {
     }
 
     // 메모 삭제
-    public ResponseEntity<DefaultResponse> deleteMemo(String token, String isbn, DeleteUuidRequest request) {
+    public ResponseEntity<DefaultResponse> deleteMemo(Long memberId, String isbn, DeleteUuidRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -1110,12 +1082,11 @@ public class BookService {
     }
 
     // 메모 전체조회
-    public ResponseEntity<DefaultResponse> getMemo(String token, String isbn) {
+    public ResponseEntity<DefaultResponse> getMemo(Long memberId, String isbn) {
         // 응답으로 보낼 메모 List
         List<GetMemoResponse> memoList = new ArrayList<>();
 
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -1150,9 +1121,8 @@ public class BookService {
     }
 
     // 책갈피 등록
-    public ResponseEntity<DefaultResponse> addBookmark(String token, String isbn, BookmarkRequest request) {
+    public ResponseEntity<DefaultResponse> addBookmark(Long memberId, String isbn, BookmarkRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -1203,9 +1173,8 @@ public class BookService {
     }
 
     // 책갈피 수정
-    public ResponseEntity<DefaultResponse> modifyBookmark(String token, String isbn, BookmarkRequest request) {
+    public ResponseEntity<DefaultResponse> modifyBookmark(Long memberId, String isbn, BookmarkRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -1275,9 +1244,8 @@ public class BookService {
     }
 
     // 책갈피 삭제
-    public ResponseEntity<DefaultResponse> deleteBookmark(String token, String isbn, DeleteUuidRequest request) {
+    public ResponseEntity<DefaultResponse> deleteBookmark(Long memberId, String isbn, DeleteUuidRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -1310,12 +1278,11 @@ public class BookService {
     }
 
     // 책갈피 전체조회
-    public ResponseEntity<DefaultResponse> getBookmark(String token, String isbn) {
+    public ResponseEntity<DefaultResponse> getBookmark(Long memberId, String isbn) {
         // 응답으로 보낼 메모 List
         List<GetBookmarkResponse> bookmarkList = new ArrayList<>();
 
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
@@ -1356,14 +1323,13 @@ public class BookService {
     }
 
     // 전체 위치 조회
-    public ResponseEntity<DefaultResponse> getAllLocation(String token, GetAllLocationRequest request) {
+    public ResponseEntity<DefaultResponse> getAllLocation(Long memberId, GetAllLocationRequest request) {
         // 응답으로 보낼 객체 리스트
         List<GetAllLocationResponse> locationInfo = new ArrayList<>();
 
         int orderNumber = request.orderNumber();
 
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // Response 전달 시 들어가는 데이터
@@ -1423,12 +1389,11 @@ public class BookService {
     }
 
     // 최근 등록 위치 조회
-    public ResponseEntity<DefaultResponse> getRecentLocation(String token) {
+    public ResponseEntity<DefaultResponse> getRecentLocation(Long memberId) {
         // 응답으로 보낼 객체 리스트
         List<GetRecentLocationResponse> location = new ArrayList<>();
 
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         List<MemberLocation> memberLocationList = memberLocationRepository.findAllByMember(member);
@@ -1445,9 +1410,8 @@ public class BookService {
     }
 
     // 최근 등록 위치 삭제
-    public ResponseEntity<DefaultResponse> deleteRecentLocation(String token, DeleteRecentLocationRequest request) {
+    public ResponseEntity<DefaultResponse> deleteRecentLocation(Long memberId, DeleteRecentLocationRequest request) {
         // 사용자 받아오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 전체 위치에서 검색

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -5,7 +5,6 @@ import com.codecozy.server.dto.request.*;
 import com.codecozy.server.dto.response.*;
 import com.codecozy.server.entity.*;
 import com.codecozy.server.repository.*;
-import com.codecozy.server.security.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,7 +30,6 @@ public class BookService {
     private final PersonalDictionaryRepository personalDictionaryRepository;
     private final MemoRepository memoRepository;
     private final BookmarkRepository bookmarkRepository;
-    private final TokenProvider tokenProvider;
 
     // 사용자가 독서노트 추가 시 실행 (책 등록, 위치 등록, 독서노트 등록, 최근 검색 위치 등록)
     public ResponseEntity<DefaultResponse> createBook(Long memberId, String isbn, ReadingBookCreateRequest request) {

--- a/server/src/main/java/com/codecozy/server/service/BookshelfService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookshelfService.java
@@ -9,7 +9,6 @@ import com.codecozy.server.entity.BookRecord;
 import com.codecozy.server.entity.Member;
 import com.codecozy.server.repository.BookRecordRepository;
 import com.codecozy.server.repository.MemberRepository;
-import com.codecozy.server.security.TokenProvider;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,15 +21,13 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 public class BookshelfService {
-    private final TokenProvider tokenProvider;
     private final ConverterService converterService;
     private final MemberRepository memberRepository;
     private final BookRecordRepository bookRecordRepository;
 
     // 책장 초기 조회
-    public ResponseEntity<DefaultResponse> getAllBookshelf(String token, int bookshelfType) {
+    public ResponseEntity<DefaultResponse> getAllBookshelf(Long memberId, int bookshelfType) {
         // 유저 정보 가져오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 해당 유저의 독서노트 모두 가져오기
@@ -186,9 +183,8 @@ public class BookshelfService {
     }
 
     // 책장 리스트용 조회
-    public ResponseEntity<DefaultResponse> getDetailBookshelf(String token, String bookshelfCode) {
+    public ResponseEntity<DefaultResponse> getDetailBookshelf(Long memberId, String bookshelfCode) {
         // 유저 정보 가져오기
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
         Member member = memberRepository.findByMemberId(memberId);
 
         // 해당 유저의 독서노트 모두 가져오기


### PR DESCRIPTION
- Service단에는 로직을 수행하기 위한 값만 넣기 위해 토큰에서 회원 아이디의 값을 빼는 과정을 Controller로 옮김
- 단, Member Service에서는 이미 tokenProvider를 사용하여 token을 발급해야 하는 로직이 있으므로 기존 상태 유지함