### PR TITLE
refactor: 알라딘 OPEN API ttbkey 값 secret file로 분리

### DIFF
--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -2048,7 +2048,7 @@ public class BookService {
             Map<String, Object> yamlData = yaml.load(inputStream);
             Map<String, Object> aladinApi = (Map<String, Object>) yamlData.get("aladin_api");
 
-            baseUrl = (String) aladinApi.get("base_url");
+            baseUrl = (String) aladinApi.get("lookup_url");
             ttbKey = (String) aladinApi.get("ttbkey");
             output = (String) ((Map<String, Object>) aladinApi.get("default_params")).get("output");
             version = (String) ((Map<String, Object>) aladinApi.get("default_params")).get("version");


### PR DESCRIPTION
## 목적🎯
알라딘 API의 ttbkey값이 깃허브에서 외부로 오픈되는 것을 방지

## 변경사항🛠️
새 ttbkey를 발급받고, 깃허브에 올라가지 않는 로컬 파일을 생성해 ttbkey를 포함한 알라딘 API 호출 url 작성 코드 리팩토링

## 수행한 테스트✏️
리팩토링한 코드가 기존 url 호출과 동일하게 작동하는지 postman으로 확인

## 비고📌
노션 Secret File List에 파일 내용 작성해뒀습니다!!☺️