### PR TITLE
refactor: Entity 간 연관 관계 재설정 2차 (완료)

### DIFF
--- a/server/src/main/java/com/codecozy/server/composite_key/BookmarkKey.java
+++ b/server/src/main/java/com/codecozy/server/composite_key/BookmarkKey.java
@@ -1,18 +1,15 @@
 package com.codecozy.server.composite_key;
 
-import com.codecozy.server.entity.Book;
-import com.codecozy.server.entity.Member;
+import com.codecozy.server.entity.BookRecord;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-
-import java.io.Serializable;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode
 public class BookmarkKey implements Serializable {
-    private Member member;
-    private Book book;
+    private BookRecord bookRecord;
     private String uuid;
 }

--- a/server/src/main/java/com/codecozy/server/composite_key/MemoKey.java
+++ b/server/src/main/java/com/codecozy/server/composite_key/MemoKey.java
@@ -1,7 +1,6 @@
 package com.codecozy.server.composite_key;
 
-import com.codecozy.server.entity.Book;
-import com.codecozy.server.entity.Member;
+import com.codecozy.server.entity.BookRecord;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -12,7 +11,6 @@ import java.io.Serializable;
 @NoArgsConstructor
 @EqualsAndHashCode
 public class MemoKey implements Serializable {
-    private Member member;
-    private Book book;
+    private BookRecord bookRecord;
     private String uuid;
 }

--- a/server/src/main/java/com/codecozy/server/composite_key/PersonalDictionaryKey.java
+++ b/server/src/main/java/com/codecozy/server/composite_key/PersonalDictionaryKey.java
@@ -1,18 +1,15 @@
 package com.codecozy.server.composite_key;
 
-import com.codecozy.server.entity.Book;
-import com.codecozy.server.entity.Member;
+import com.codecozy.server.entity.BookRecord;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-
 import java.io.Serializable;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode
 public class PersonalDictionaryKey implements Serializable {
-    private Member member;
-    private Book book;
+    private BookRecord bookRecord;
     private String name;
 }

--- a/server/src/main/java/com/codecozy/server/entity/Book.java
+++ b/server/src/main/java/com/codecozy/server/entity/Book.java
@@ -44,9 +44,6 @@ public class Book {
     private List<BookRecord> bookRecords;
 
     @OneToMany(mappedBy = "book", cascade = CascadeType.REMOVE)
-    private List<Memo> memos;
-
-    @OneToMany(mappedBy = "book", cascade = CascadeType.REMOVE)
     private List<PersonalDictionary> personalDictionaries;
 
     public Book(String isbn) {

--- a/server/src/main/java/com/codecozy/server/entity/Book.java
+++ b/server/src/main/java/com/codecozy/server/entity/Book.java
@@ -43,9 +43,6 @@ public class Book {
     @OneToMany(mappedBy = "book", cascade = CascadeType.REMOVE)
     private List<BookRecord> bookRecords;
 
-    @OneToMany(mappedBy = "book", cascade = CascadeType.REMOVE)
-    private List<PersonalDictionary> personalDictionaries;
-
     public Book(String isbn) {
         this.isbn = isbn;
     }

--- a/server/src/main/java/com/codecozy/server/entity/Book.java
+++ b/server/src/main/java/com/codecozy/server/entity/Book.java
@@ -41,9 +41,6 @@ public class Book {
     private LocalDate publicationDate;
 
     @OneToMany(mappedBy = "book", cascade = CascadeType.REMOVE)
-    private List<Bookmark> bookmarks;
-
-    @OneToMany(mappedBy = "book", cascade = CascadeType.REMOVE)
     private List<BookRecord> bookRecords;
 
     @OneToMany(mappedBy = "book", cascade = CascadeType.REMOVE)

--- a/server/src/main/java/com/codecozy/server/entity/BookRecord.java
+++ b/server/src/main/java/com/codecozy/server/entity/BookRecord.java
@@ -4,6 +4,7 @@ import com.codecozy.server.composite_key.BookRecordKey;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -71,6 +72,9 @@ public class BookRecord {
 
     @OneToOne(mappedBy = "bookRecord", cascade = CascadeType.REMOVE)
     private SelectReview selectReview;
+
+    @OneToMany(mappedBy = "bookRecord", cascade = CascadeType.REMOVE)
+    private List<Bookmark> bookmarks;
 
     public void setReadingStatus(int readingStatus) { this.readingStatus = readingStatus; }
 

--- a/server/src/main/java/com/codecozy/server/entity/BookRecord.java
+++ b/server/src/main/java/com/codecozy/server/entity/BookRecord.java
@@ -79,6 +79,9 @@ public class BookRecord {
     @OneToMany(mappedBy = "bookRecord", cascade = CascadeType.REMOVE)
     private List<Memo> memos;
 
+    @OneToMany(mappedBy = "bookRecord", cascade = CascadeType.REMOVE)
+    private List<PersonalDictionary> personalDictionaries;
+
     public void setReadingStatus(int readingStatus) { this.readingStatus = readingStatus; }
 
     public void setBookType(int bookType) { this.bookType = bookType; }

--- a/server/src/main/java/com/codecozy/server/entity/BookRecord.java
+++ b/server/src/main/java/com/codecozy/server/entity/BookRecord.java
@@ -76,6 +76,9 @@ public class BookRecord {
     @OneToMany(mappedBy = "bookRecord", cascade = CascadeType.REMOVE)
     private List<Bookmark> bookmarks;
 
+    @OneToMany(mappedBy = "bookRecord", cascade = CascadeType.REMOVE)
+    private List<Memo> memos;
+
     public void setReadingStatus(int readingStatus) { this.readingStatus = readingStatus; }
 
     public void setBookType(int bookType) { this.bookType = bookType; }

--- a/server/src/main/java/com/codecozy/server/entity/Bookmark.java
+++ b/server/src/main/java/com/codecozy/server/entity/Bookmark.java
@@ -18,13 +18,11 @@ import lombok.NoArgsConstructor;
 public class Bookmark {
     @Id
     @ManyToOne
-    @JoinColumn(name = "member_id", referencedColumnName = "member_id")
-    private Member member;
-
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "isbn", referencedColumnName = "isbn")
-    private Book book;
+    @JoinColumns({
+            @JoinColumn(name = "member_id", referencedColumnName = "member_id"),
+            @JoinColumn(name = "isbn", referencedColumnName = "isbn")
+    })
+    private BookRecord bookRecord;
 
     @Id
     @Column(length = 40, nullable = false)
@@ -40,10 +38,9 @@ public class Bookmark {
     @Column(nullable = false)
     private LocalDate date;
 
-    public static Bookmark create(Member member, Book book, String uuid, int markPage, LocationList locationList, LocalDate date) {
+    public static Bookmark create(BookRecord bookRecord, String uuid, int markPage, LocationList locationList, LocalDate date) {
         return Bookmark.builder()
-                .member(member)
-                .book(book)
+                .bookRecord(bookRecord)
                 .uuid(uuid)
                 .markPage(markPage)
                 .locationList(locationList)

--- a/server/src/main/java/com/codecozy/server/entity/LocationList.java
+++ b/server/src/main/java/com/codecozy/server/entity/LocationList.java
@@ -41,11 +41,6 @@ public class LocationList {
     @OneToMany(mappedBy = "locationList", cascade = CascadeType.REMOVE)
     private List<BookRecord> bookRecords;
 
-    public void setPlaceName(String placeName) { this.placeName = placeName; }
-    public void setAddress(String address) { this.address = address; }
-    public void setLatitude(double latitude) { this.latitude = latitude; }
-    public void setLongitude(double longitude) { this.longitude = longitude; }
-
     public static LocationList create(String placeName, String address, double latitude, double longitude) {
         return LocationList.builder()
                 .placeName(placeName)

--- a/server/src/main/java/com/codecozy/server/entity/Member.java
+++ b/server/src/main/java/com/codecozy/server/entity/Member.java
@@ -44,9 +44,6 @@ public class Member {
     private List<MemberLocation> memberLocations;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
-    private List<PersonalDictionary> personalDictionaries;
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<BookReviewReviewer> bookReviewReviewers;
 
     public static Member create(String nickname, String profile) {

--- a/server/src/main/java/com/codecozy/server/entity/Member.java
+++ b/server/src/main/java/com/codecozy/server/entity/Member.java
@@ -38,9 +38,6 @@ public class Member {
     private List<Badge> badges;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
-    private List<Bookmark> bookmarks;
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<BookRecord> bookRecords;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)

--- a/server/src/main/java/com/codecozy/server/entity/Member.java
+++ b/server/src/main/java/com/codecozy/server/entity/Member.java
@@ -44,9 +44,6 @@ public class Member {
     private List<MemberLocation> memberLocations;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
-    private List<Memo> memos;
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<PersonalDictionary> personalDictionaries;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)

--- a/server/src/main/java/com/codecozy/server/entity/Memo.java
+++ b/server/src/main/java/com/codecozy/server/entity/Memo.java
@@ -15,13 +15,11 @@ import lombok.*;
 public class Memo {
     @Id
     @ManyToOne
-    @JoinColumn(name = "member_id", referencedColumnName = "member_id")
-    private Member member;
-
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "isbn", referencedColumnName = "isbn")
-    private Book book;
+    @JoinColumns({
+            @JoinColumn(name = "member_id", referencedColumnName = "member_id"),
+            @JoinColumn(name = "isbn", referencedColumnName = "isbn")
+    })
+    private BookRecord bookRecord;
 
     @Id
     @Column(length = 40, nullable = false)
@@ -36,10 +34,9 @@ public class Memo {
     @Column(name = "memo_text", length = 1000, nullable = false)
     private String memoText;
 
-    public static Memo create(Member member, Book book, String uuid, int markPage, LocalDate date, String memoText) {
+    public static Memo create(BookRecord bookRecord, String uuid, int markPage, LocalDate date, String memoText) {
         return Memo.builder()
-                .member(member)
-                .book(book)
+                .bookRecord(bookRecord)
                 .uuid(uuid)
                 .markPage(markPage)
                 .date(date)

--- a/server/src/main/java/com/codecozy/server/entity/PersonalDictionary.java
+++ b/server/src/main/java/com/codecozy/server/entity/PersonalDictionary.java
@@ -17,13 +17,11 @@ import lombok.NoArgsConstructor;
 public class PersonalDictionary {
     @Id
     @ManyToOne
-    @JoinColumn(name = "member_id", referencedColumnName = "member_id")
-    private Member member;
-
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "isbn", referencedColumnName = "isbn")
-    private Book book;
+    @JoinColumns({
+            @JoinColumn(name = "member_id", referencedColumnName = "member_id"),
+            @JoinColumn(name = "isbn", referencedColumnName = "isbn")
+    })
+    private BookRecord bookRecord;
 
     @Id
     @Column(length = 20, nullable = false)
@@ -38,10 +36,9 @@ public class PersonalDictionary {
     @Column(length = 1000)
     private String description;
 
-    public static PersonalDictionary create(Member member, Book book, String name, int emoji, String preview, String description) {
+    public static PersonalDictionary create(BookRecord bookRecord, String name, int emoji, String preview, String description) {
         return PersonalDictionary.builder()
-                .member(member)
-                .book(book)
+                .bookRecord(bookRecord)
                 .name(name)
                 .emoji(emoji)
                 .preview(preview)

--- a/server/src/main/java/com/codecozy/server/repository/BookmarkRepository.java
+++ b/server/src/main/java/com/codecozy/server/repository/BookmarkRepository.java
@@ -1,27 +1,28 @@
 package com.codecozy.server.repository;
 
 import com.codecozy.server.composite_key.BookmarkKey;
-import com.codecozy.server.entity.Book;
+import com.codecozy.server.entity.BookRecord;
 import com.codecozy.server.entity.Bookmark;
 import com.codecozy.server.entity.LocationList;
 import com.codecozy.server.entity.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface BookmarkRepository extends JpaRepository<Bookmark, BookmarkKey> {
-    Bookmark findByMemberAndBookAndUuid(Member member, Book book, String uuid);
+    // 특정 독서노트에서 uuid로 책갈피 찾기
+    Bookmark findByBookRecordAndUuid(BookRecord bookRecord, String uuid);
 
     // 특정 유저의 모든 책갈피 가져오기
-    List<Bookmark> findAllByMember(Member member);
+    List<Bookmark> findAllByBookRecordMember(Member member);
 
-    List<Bookmark> findAllByMemberAndBook(Member member, Book book);
+    // 특정 독서노트에 쓴 모든 책갈피 가져오기
+    List<Bookmark> findAllByBookRecord(BookRecord bookRecord);
 
     Long countByLocationList(LocationList locationList);
 
     // 특정 유저의 책갈피 중 locationId 값으로 검색하기
-    List<Bookmark> findAllByMemberAndLocationList(Member member, LocationList locationList);
+    List<Bookmark> findAllByBookRecordMemberAndLocationList(Member member, LocationList locationList);
 
-    // 특정 유저의 최근 책갈피 3개 가져오기
-    List<Bookmark> findTop3ByMemberAndBookOrderByDateDesc(Member member, Book book);
+    // 특정 독서노트의 최근 책갈피 3개 가져오기
+    List<Bookmark> findTop3ByBookRecordOrderByDateDesc(BookRecord bookRecord);
 }

--- a/server/src/main/java/com/codecozy/server/repository/MemoRepository.java
+++ b/server/src/main/java/com/codecozy/server/repository/MemoRepository.java
@@ -1,17 +1,19 @@
 package com.codecozy.server.repository;
 
 import com.codecozy.server.composite_key.MemoKey;
-import com.codecozy.server.entity.Book;
-import com.codecozy.server.entity.Member;
+import com.codecozy.server.entity.BookRecord;
 import com.codecozy.server.entity.Memo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface MemoRepository extends JpaRepository<Memo, MemoKey> {
-    Memo findByMemberAndBookAndUuid(Member member, Book book, String uuid);
-    List<Memo> findAllByMemberAndBook(Member member, Book book);
+    // 특정 독서노트 내에서 uuid로 메모 찾기
+    Memo findByBookRecordAndUuid(BookRecord bookRecord, String uuid);
 
-    // 특정 유저의 최근 3개의 메모 가져오기
-    List<Memo> findTop3ByMemberAndBookOrderByDateDesc(Member member, Book book);
+    // 특정 독서노트 내에 있는 모든 메모 찾기
+    List<Memo> findAllByBookRecord(BookRecord bookRecord);
+
+    // 특정 독서노트 내에 작성된 최근 3개의 메모 가져오기
+    List<Memo> findTop3ByBookRecordOrderByDateDesc(BookRecord bookRecord);
 }

--- a/server/src/main/java/com/codecozy/server/repository/PersonalDictionaryRepository.java
+++ b/server/src/main/java/com/codecozy/server/repository/PersonalDictionaryRepository.java
@@ -1,17 +1,19 @@
 package com.codecozy.server.repository;
 
 import com.codecozy.server.composite_key.PersonalDictionaryKey;
-import com.codecozy.server.entity.Book;
-import com.codecozy.server.entity.Member;
+import com.codecozy.server.entity.BookRecord;
 import com.codecozy.server.entity.PersonalDictionary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface PersonalDictionaryRepository extends JpaRepository<PersonalDictionary, PersonalDictionaryKey> {
-    PersonalDictionary findByMemberAndBookAndName(Member member, Book book, String name);
-    List<PersonalDictionary> findAllByMemberAndBook(Member member, Book book);
+    // 특정 독서노트 내에서 이름으로 인물사전 찾기
+    PersonalDictionary findByBookRecordAndName(BookRecord bookRecord, String name);
 
-    // 특정 유저의 이름순 3개 인물사전 가져오기
-    List<PersonalDictionary> findTop3ByMemberAndBookOrderByNameAsc(Member member, Book book);
+    // 특정 독서노트 내에 있는 모든 인물사전 가져오기
+    List<PersonalDictionary> findAllByBookRecord(BookRecord bookRecord);
+
+    // 특정 독서노트 내의 이름순 3개 인물사전 가져오기
+    List<PersonalDictionary> findTop3ByBookRecordOrderByNameAsc(BookRecord bookRecord);
 }

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -198,7 +198,7 @@ public class BookService {
             ));
         }
 
-        List<Memo> memoList = memoRepository.findTop3ByMemberAndBookOrderByDateDesc(member, book);
+        List<Memo> memoList = memoRepository.findTop3ByBookRecordOrderByDateDesc(bookRecord);
         List<MemoResponse> memos = new ArrayList<>();
         for (Memo memo : memoList) {
             int markPage = memo.getMarkPage();
@@ -1353,7 +1353,10 @@ public class BookService {
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
 
-        Memo memo = memoRepository.findByMemberAndBookAndUuid(member, book, request.uuid());
+        // 독서노트 가져오기
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
+        Memo memo = memoRepository.findByBookRecordAndUuid(bookRecord, request.uuid());
         if (memo != null) {
             return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "이미 등록한 메모입니다."),
                     HttpStatus.CONFLICT);
@@ -1361,7 +1364,6 @@ public class BookService {
 
         // 최근 날짜와 비교해 더 최근이면 수정
         LocalDate date = converterService.stringToDate(request.date());
-        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
         if (bookRecord.getRecentDate() == null) {
             bookRecord.setRecentDate(date);
         } else {
@@ -1400,7 +1402,7 @@ public class BookService {
         }
 
         // 메모가 있으면
-        Memo memo = memoRepository.findByMemberAndBookAndUuid(member, book, request.uuid());
+        Memo memo = memoRepository.findByBookRecordAndUuid(bookRecord, request.uuid());
         if (memo != null) {
             memo = Memo.create(bookRecord, request.uuid(), request.markPage(), date, request.memoText());
             memoRepository.save(memo);
@@ -1427,8 +1429,11 @@ public class BookService {
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
 
+        // 독서노트 가져오기
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
         // 메모가 있으면
-        Memo memo = memoRepository.findByMemberAndBookAndUuid(member, book, request.uuid());
+        Memo memo = memoRepository.findByBookRecordAndUuid(bookRecord, request.uuid());
         if (memo != null) {
             // 메모 삭제
             memoRepository.delete(memo);
@@ -1454,8 +1459,11 @@ public class BookService {
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
 
+        // 독서노트 가져오기
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
         // 한 유저의 한 책에 대한 메모 전체 검색
-        List<Memo> memos = memoRepository.findAllByMemberAndBook(member, book);
+        List<Memo> memos = memoRepository.findAllByBookRecord(bookRecord);
         for (int i = 0; i < memos.size(); i++) {
             Memo memo = memos.get(i);
 

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -214,8 +214,8 @@ public class BookService {
             ));
         }
 
-        List<PersonalDictionary> personalDictionaryList = personalDictionaryRepository.findTop3ByMemberAndBookOrderByNameAsc(
-                member, book);
+        List<PersonalDictionary> personalDictionaryList =
+                personalDictionaryRepository.findTop3ByBookRecordOrderByNameAsc(bookRecord);
         List<PersonalDictionaryPreviewResponse> characters = new ArrayList<>();
         for (PersonalDictionary personalDictionary : personalDictionaryList) {
             characters.add(new PersonalDictionaryPreviewResponse(
@@ -1246,7 +1246,7 @@ public class BookService {
         BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
 
         // 해당 인물이 중복됐는지 검색
-        PersonalDictionary personalDictionary = personalDictionaryRepository.findByMemberAndBookAndName(member, book,
+        PersonalDictionary personalDictionary = personalDictionaryRepository.findByBookRecordAndName(bookRecord,
                 request.name());
 
         // 중복된 인물이면 (이름이 중복됐으면)
@@ -1278,8 +1278,8 @@ public class BookService {
         BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
 
         // 해당 인물이 있는지 검색
-        PersonalDictionary personalDictionary = personalDictionaryRepository.findByMemberAndBookAndName(member, book,
-                request.name());
+        PersonalDictionary personalDictionary =
+                personalDictionaryRepository.findByBookRecordAndName(bookRecord, request.name());
 
         // 중복된 인물이면 (이름이 중복됐으면)
         if (personalDictionary != null) {
@@ -1306,8 +1306,12 @@ public class BookService {
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
 
+        // 독서노트 가져오기
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
         // 해당 인물이 있는지 검색
-        PersonalDictionary personalDictionary = personalDictionaryRepository.findByMemberAndBookAndName(member, book, request.name());
+        PersonalDictionary personalDictionary =
+                personalDictionaryRepository.findByBookRecordAndName(bookRecord, request.name());
         if (personalDictionary != null) {
             // 인물사전에서 삭제
             personalDictionaryRepository.delete(personalDictionary);
@@ -1334,9 +1338,12 @@ public class BookService {
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
 
+        // 독서노트 가져오기
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
         // 한 유저의 한 책에 대한 인물사전 전체 검색
-        List<PersonalDictionary> personalDictionaries = personalDictionaryRepository.findAllByMemberAndBook(member,
-                book);
+        List<PersonalDictionary> personalDictionaries =
+                personalDictionaryRepository.findAllByBookRecord(bookRecord);
         for (int i = 0; i < personalDictionaries.size(); i++) {
             PersonalDictionary personalDictionary = personalDictionaries.get(i);
 

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -182,7 +182,7 @@ public class BookService {
             log.info("해당 책의 마지막으로 읽은 날짜 없음");
         }
 
-        List<Bookmark> bookmarkList = bookmarkRepository.findTop3ByMemberAndBookOrderByDateDesc(member, book);
+        List<Bookmark> bookmarkList = bookmarkRepository.findTop3ByBookRecordOrderByDateDesc(bookRecord);
         List<BookmarkPreviewResponse> bookmarks = new ArrayList<>();
         for (Bookmark bookmark : bookmarkList) {
             int markPage = bookmark.getMarkPage();
@@ -1492,7 +1492,10 @@ public class BookService {
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
 
-        Bookmark bookmark = bookmarkRepository.findByMemberAndBookAndUuid(member, book, request.uuid());
+        // 해당 독서노트 가져오기
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
+        Bookmark bookmark = bookmarkRepository.findByBookRecordAndUuid(bookRecord, request.uuid());
         if (bookmark != null) {
             return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "이미 등록한 책갈피입니다."),
                     HttpStatus.CONFLICT);
@@ -1520,7 +1523,6 @@ public class BookService {
         }
 
         // 책갈피 페이지에 따른 읽는중, 다읽음 수정
-        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
         bookRecord.setMarkPage(request.markPage());
         if (bookRecord.getBookType() == 0) { // 종이책인 경우
             if (request.markPage() >= book.getTotalPage()) { // 책갈피 페이지가 전체 페이지보다 같거나 크면
@@ -1573,8 +1575,11 @@ public class BookService {
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
 
+        // 독서노트 가져오기
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
         // 책갈피가 있으면
-        Bookmark bookmark = bookmarkRepository.findByMemberAndBookAndUuid(member, book, request.uuid());
+        Bookmark bookmark = bookmarkRepository.findByBookRecordAndUuid(bookRecord, request.uuid());
         if (bookmark != null) {
 
             // 수정할 위치를 받았으면
@@ -1615,7 +1620,6 @@ public class BookService {
             }
 
             // 최근 날짜와 비교해 더 최근이면 수정
-            BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
             bookRecord.setMarkPage(request.markPage());
             LocalDate date = converterService.stringToDate(request.date());
             if (date.isAfter(bookRecord.getRecentDate())) {
@@ -1649,8 +1653,11 @@ public class BookService {
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
 
+        // 독서노트 가져오기
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
         // 책갈피가 있으면
-        Bookmark bookmark = bookmarkRepository.findByMemberAndBookAndUuid(member, book, request.uuid());
+        Bookmark bookmark = bookmarkRepository.findByBookRecordAndUuid(bookRecord, request.uuid());
         if (bookmark != null) {
             // 위치 정보를 포함하고 있으면
             if (bookmark.getLocationList() != null) {
@@ -1693,8 +1700,11 @@ public class BookService {
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
 
+        // 독서노트 가져오기
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
         // 한 유저의 한 책에 대한 메모 전체 검색
-        List<Bookmark> bookmarks = bookmarkRepository.findAllByMemberAndBook(member, book);
+        List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecord(bookRecord);
         for (int i = 0; i < bookmarks.size(); i++) {
             Bookmark bookmark = bookmarks.get(i);
 
@@ -1783,7 +1793,7 @@ public class BookService {
         }
 
         // 책갈피에서 정보 받아오기
-        List<Bookmark> bookmarks = bookmarkRepository.findAllByMember(member);
+        List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecordMember(member);
         size = bookmarks.size();
         Bookmark bookmark;
         for (int i = (orderNumber * 20); i < 20 + (orderNumber * 20); i++) {
@@ -1897,7 +1907,7 @@ public class BookService {
         }
 
         // 북마크(1)에서 검색
-        List<Bookmark> bookmarks = bookmarkRepository.findAllByMember(member);
+        List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecordMember(member);
         for (Bookmark bookmark : bookmarks) {
             LocationList location = bookmark.getLocationList();
             allMarkers.add(new AllMarkerResponse(location.getLocationId(), location.getLatitude(), location.getLongitude(), true));
@@ -1964,7 +1974,7 @@ public class BookService {
         }
 
         // 책갈피에서 해당 위치 검색
-        List<Bookmark> bookmarks = bookmarkRepository.findAllByMemberAndLocationList(member, locationList);
+        List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecordMemberAndLocationList(member, locationList);
         size = bookmarks.size();
         Bookmark bookmark;
         for (int i = (orderNumber * 20); i < 20 + (orderNumber * 20); i++) {

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1370,7 +1370,7 @@ public class BookService {
             }
         }
 
-        memo = Memo.create(member, book, request.uuid(), request.markPage(), date, request.memoText());
+        memo = Memo.create(bookRecord, request.uuid(), request.markPage(), date, request.memoText());
         memoRepository.save(memo);
 
         // 독서노트의 마지막 기록 날짜 업데이트
@@ -1402,7 +1402,7 @@ public class BookService {
         // 메모가 있으면
         Memo memo = memoRepository.findByMemberAndBookAndUuid(member, book, request.uuid());
         if (memo != null) {
-            memo = Memo.create(member, book, request.uuid(), request.markPage(), date, request.memoText());
+            memo = Memo.create(bookRecord, request.uuid(), request.markPage(), date, request.memoText());
             memoRepository.save(memo);
         } else {
             return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "등록하지 않은 메모입니다."),

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -834,7 +834,6 @@ public class BookService {
         }
 
         // 독서노트에 첫 리뷰 날짜 기록
-        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
         bookRecord.setFirstReviewDate(converterService.stringToDate(request.date()));
 
         // 최근 날짜와 비교해 더 최근이면 수정
@@ -1553,7 +1552,7 @@ public class BookService {
         bookRecordRepository.save(bookRecord);
 
         // 책갈피 생성, 저장
-        bookmark = Bookmark.create(member, book, request.uuid(), request.markPage(), locationList, date);
+        bookmark = Bookmark.create(bookRecord, request.uuid(), request.markPage(), locationList, date);
         bookmarkRepository.save(bookmark);
 
         // 독서노트의 마지막 기록 날짜 업데이트
@@ -1625,7 +1624,7 @@ public class BookService {
             }
 
             // 페이지 그대로 책갈피 등록
-            bookmark = Bookmark.create(member, book, request.uuid(), request.markPage(), locationList, date);
+            bookmark = Bookmark.create(bookRecord, request.uuid(), request.markPage(), locationList, date);
             bookmarkRepository.save(bookmark);
 
             // 독서노트의 마지막 기록 날짜 업데이트
@@ -1802,7 +1801,7 @@ public class BookService {
             }
 
             date = converterService.dateToString(bookmark.getDate());
-            title = bookmark.getBook().getTitle();
+            title = bookmark.getBookRecord().getBook().getTitle();
             readPage = bookmark.getMarkPage();
             locationId = bookmark.getLocationList().getLocationId();
             placeName = bookmark.getLocationList().getPlaceName();
@@ -1983,7 +1982,7 @@ public class BookService {
             }
 
             date = converterService.dateToString(bookmark.getDate());
-            title = bookmark.getBook().getTitle();
+            title = bookmark.getBookRecord().getBook().getTitle();
             readPage = bookmark.getMarkPage();
             locationId = bookmark.getLocationList().getLocationId();
             placeName = bookmark.getLocationList().getPlaceName();

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1242,6 +1242,9 @@ public class BookService {
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
 
+        // 독서노트 가져오기
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
         // 해당 인물이 중복됐는지 검색
         PersonalDictionary personalDictionary = personalDictionaryRepository.findByMemberAndBookAndName(member, book,
                 request.name());
@@ -1252,7 +1255,7 @@ public class BookService {
                     HttpStatus.CONFLICT);
         } else {
             // 인물사전에 등록
-            personalDictionary = PersonalDictionary.create(member, book, request.name(),
+            personalDictionary = PersonalDictionary.create(bookRecord, request.name(),
                     Integer.parseInt(request.emoji()), request.preview(), request.description());
             personalDictionaryRepository.save(personalDictionary);
         }
@@ -1271,6 +1274,9 @@ public class BookService {
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
 
+        // 독서노트 가져오기
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
         // 해당 인물이 있는지 검색
         PersonalDictionary personalDictionary = personalDictionaryRepository.findByMemberAndBookAndName(member, book,
                 request.name());
@@ -1278,7 +1284,7 @@ public class BookService {
         // 중복된 인물이면 (이름이 중복됐으면)
         if (personalDictionary != null) {
             // 인물사전에서 수정 등록
-            personalDictionary = PersonalDictionary.create(member, book, request.name(),
+            personalDictionary = PersonalDictionary.create(bookRecord, request.name(),
                     Integer.parseInt(request.emoji()), request.preview(), request.description());
             personalDictionaryRepository.save(personalDictionary);
         } else {

--- a/server/src/test/java/com/codecozy/server/repository/BookReviewRepositoryTest.java
+++ b/server/src/test/java/com/codecozy/server/repository/BookReviewRepositoryTest.java
@@ -22,53 +22,40 @@ class BookReviewRepositoryTest {
     private TestEntityManager testEntityManager;
 
     @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private BookRepository bookRepository;
-
-    @Autowired
     private BookRecordRepository bookRecordRepository;
 
     @Autowired
     private BookReviewRepository bookReviewRepository;
 
-    // 테스트를 위한 ID값 저장
-    private String bookIsbn = "9791190090018";
-    private Long memberId;
-    private Long bookReviewId;
+    private Member member;
+    private Book book;
+    private BookRecord bookRecord;
 
     @BeforeEach
     void setup() {
         // 가입 회원 세팅 (2명)
-        Member member1 = memberRepository.save(Member.create("이름1", "01"));
-        Member member2 = memberRepository.save(Member.create("이름2", "11"));
-
-        memberId = member1.getMemberId();
+        member = testEntityManager.persist(Member.create("이름1", "01"));
+        Member member2 = testEntityManager.persist(Member.create("이름2", "11"));
 
         // 테스트 책 세팅
-        Book book = bookRepository.save(
+        book = testEntityManager.persist(
                 Book.create(
-                        bookIsbn,
+                        "9791190090018",
                         "http://example.com/cover.jpg",
                         "제목",
                         "작가",
                         "과학",
                         300,
                         "출판사",
-                        LocalDate.now())
-        );
+                        LocalDate.now()));
 
         // 독서노트 세팅
-        BookRecord bookRecord1 = bookRecordRepository.save(BookRecord.create(member1, book));
-        BookRecord bookRecord2 = bookRecordRepository.save(BookRecord.create(member2, book));
+        bookRecord = testEntityManager.persist(BookRecord.create(member, book));
+        BookRecord bookRecord2 = testEntityManager.persist(BookRecord.create(member2, book));
 
         // 한줄평 세팅
-        BookReview bookReview = bookReviewRepository.save(BookReview.create(bookRecord1,
-                "재밌음"));
-        bookReviewRepository.save(BookReview.create(bookRecord2, "흥미로웠음"));
-
-        bookReviewId = bookReview.getCommentId();
+        testEntityManager.persist(BookReview.create(bookRecord, "재밌음"));
+        testEntityManager.persist(BookReview.create(bookRecord2, "흥미로웠음"));
 
         // 데이터베이스 동기화 및 영속성 context 초기화
         testEntityManager.flush();
@@ -79,40 +66,34 @@ class BookReviewRepositoryTest {
     @DisplayName("독서노트 삭제시 한줄평 삭제 여부 확인")
     void deleteTest() {
         // given
-        BookRecord bookRecord = bookReviewRepository.findById(bookReviewId).get().getBookRecord();
+        BookRecord foundBookRecord = testEntityManager.find(BookRecord.class,
+                testEntityManager.getId(bookRecord));
 
         // when
         // 부모 객체 삭제
-        bookRecordRepository.delete(bookRecord);
+        testEntityManager.remove(foundBookRecord);
 
         // then
+        // 부모 객체 삭제 확인
+        assertThat(bookRecordRepository.findByMemberAndBook(member, book)).isNull();
         // 자식 객체도 삭제되었는지 검증
-        assertThat(bookReviewRepository.findById(bookReviewId)).isEmpty();
+        assertThat(bookReviewRepository.findByBookRecord(bookRecord)).isNull();
     }
 
     @Test
     @DisplayName("독서노트 정보로 한줄평 불러오기")
     void findByBookRecord() {
-        // given
-        Member member = memberRepository.findByMemberId(memberId);
-        Book book = bookRepository.findByIsbn(bookIsbn);
-        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
-
         // when
         BookReview bookReview = bookReviewRepository.findByBookRecord(bookRecord);
 
         // then
         assertThat(bookReview).isNotNull();
         assertThat(bookReview.getReviewText()).isEqualTo("재밌음");
-        assertThat(bookReview.getBookRecord()).isEqualTo(bookRecord);
     }
 
     @Test
     @DisplayName("특정 책의 총 한줄평 개수 불러오기")
     void countByBookRecordBook() {
-        // given
-        Book book = bookRepository.findByIsbn(bookIsbn);
-
         // when
         int reviewCount = bookReviewRepository.countByBookRecordBook(book);
 
@@ -123,9 +104,6 @@ class BookReviewRepositoryTest {
     @Test
     @DisplayName("특정 책의 모든 한줄평 정보 불러오기")
     void findAllByBookRecordBook() {
-        // given
-        Book book = bookRepository.findByIsbn(bookIsbn);
-
         // when
         List<BookReview> bookReviews = bookReviewRepository.findAllByBookRecordBook(book);
 
@@ -139,9 +117,6 @@ class BookReviewRepositoryTest {
     @Test
     @DisplayName("특정 책의 모든 한줄평 정보를 최근 날짜 순으로 불러오기")
     void findAllByBookRecordBookOrderByReviewDateDesc() {
-        // given
-        Book book = bookRepository.findByIsbn(bookIsbn);
-
         // when
         List<BookReview> bookReviews = bookReviewRepository
                 .findAllByBookRecordBookOrderByReviewDateDesc(book);

--- a/server/src/test/java/com/codecozy/server/repository/BookmarkRepositoryTest.java
+++ b/server/src/test/java/com/codecozy/server/repository/BookmarkRepositoryTest.java
@@ -23,33 +23,24 @@ class BookmarkRepositoryTest {
     private TestEntityManager testEntityManager;
 
     @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private BookRepository bookRepository;
-
-    @Autowired
-    private LocationRepository locationRepository;
-
-    @Autowired
     private BookRecordRepository bookRecordRepository;
 
     @Autowired
     private BookmarkRepository bookmarkRepository;
 
-    private final String isbn = "9791190090018";
     private final String uuid = "b1526767-b6bc-427e-9f11-825ed2084cc8";
 
-    private Long memberId;
-    private Long locationId;
+    private Member member;
+    private Book book;
+    private LocationList location;
+    private BookRecord bookRecord;
 
     @BeforeEach
     void setup() {
         // 유저, 책 세팅
-        Member member = memberRepository.save(Member.create("이름", "01"));
-        memberId = member.getMemberId();
-        Book book = bookRepository.save(Book.create(
-                isbn,
+        member = testEntityManager.persist(Member.create("이름", "01"));
+        book = testEntityManager.persist(Book.create(
+                "9791190090018",
                 "http://example.com/cover.jpg",
                 "제목",
                 "작가",
@@ -59,30 +50,29 @@ class BookmarkRepositoryTest {
                 LocalDate.now()));
 
         // 위치 세팅
-        LocationList location = locationRepository.save(LocationList.create(
+        location = testEntityManager.persist(LocationList.create(
                 "학교",
                 "서울시",
                 52,
                 62));
-        locationId = location.getLocationId();
 
         // 독서노트 생성
-        BookRecord bookRecord = bookRecordRepository.save(BookRecord.create(member, book));
+        bookRecord = testEntityManager.persist(BookRecord.create(member, book));
 
         // 책갈피 추가 (3개)
-        bookmarkRepository.save(Bookmark.create(
+        testEntityManager.persist(Bookmark.create(
                 bookRecord,
                 uuid,
                 10,
                 location,
                 LocalDate.of(2024, 12, 1)));
-        bookmarkRepository.save(Bookmark.create(
+        testEntityManager.persist(Bookmark.create(
                 bookRecord,
                 "1a7599b0-a79b-4410-b2ce-d03a6a4c9bb9",
                 25,
                 location,
                 LocalDate.of(2024, 12, 5)));
-        bookmarkRepository.save(Bookmark.create(
+        testEntityManager.persist(Bookmark.create(
                 bookRecord,
                 "05e1dcbc-e630-41ec-898a-1b22474fbb78",
                 50,
@@ -98,12 +88,11 @@ class BookmarkRepositoryTest {
     @DisplayName("독서노트(부모) 삭제 시 책갈피(자식)가 삭제된다")
     void deleteTest() {
         // given
-        Member member = memberRepository.findByMemberId(memberId);
-        Book book = bookRepository.findByIsbn(isbn);
-        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+        BookRecord foundBookRecord = testEntityManager.find(BookRecord.class,
+                testEntityManager.getId(bookRecord));
 
         // when
-        bookRecordRepository.delete(bookRecord);
+        testEntityManager.remove(foundBookRecord);
 
         // then
         // 부모 삭제 확인
@@ -115,16 +104,10 @@ class BookmarkRepositoryTest {
     @Test
     @DisplayName("특정 독서노트와 uuid로 책갈피 찾기")
     void findByBookRecordAndUuid() {
-        // given
-        Member member = memberRepository.findByMemberId(memberId);
-        Book book = bookRepository.findByIsbn(isbn);
-        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
-
         // when
         Bookmark bookmark = bookmarkRepository.findByBookRecordAndUuid(bookRecord, uuid);
 
         // then
-        assertThat(bookmark.getBookRecord().getMember()).isEqualTo(member);
         assertThat(bookmark.getMarkPage()).isEqualTo(10);
         assertThat(bookmark.getDate()).isEqualTo(LocalDate.of(2024, 12, 1));
     }
@@ -132,9 +115,6 @@ class BookmarkRepositoryTest {
     @Test
     @DisplayName("특정 유저의 모든 책갈피 찾기")
     void findAllByBookRecordMember() {
-        // given
-        Member member = memberRepository.findByMemberId(memberId);
-
         // when
         List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecordMember(member);
 
@@ -147,11 +127,6 @@ class BookmarkRepositoryTest {
     @Test
     @DisplayName("특정 독서노트의 모든 책갈피 찾기")
     void findAllByBookRecord() {
-        // given
-        Member member = memberRepository.findByMemberId(memberId);
-        Book book = bookRepository.findByIsbn(isbn);
-        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
-
         // when
         List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecord(bookRecord);
 
@@ -164,10 +139,6 @@ class BookmarkRepositoryTest {
     @Test
     @DisplayName("특정 유저, 특정 위치에 있는 모든 책갈피 찾기")
     void findAllByBookRecordMemberAndLocationList() {
-        // given
-        Member member = memberRepository.findByMemberId(memberId);
-        LocationList location = locationRepository.findByLocationId(locationId);
-
         // when
         List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecordMemberAndLocationList(
                 member, location);
@@ -182,12 +153,10 @@ class BookmarkRepositoryTest {
     @DisplayName("특정 독서노트의 최근 책갈피 3개 불러오기")
     void findTop3ByBookRecordOrderByDateDesc() {
         // given
-        Member member = memberRepository.findByMemberId(memberId);
-        Book book = bookRepository.findByIsbn(isbn);
-        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
-        LocationList location = locationRepository.findByLocationId(locationId);
+        bookRecord = testEntityManager.find(BookRecord.class,
+                testEntityManager.getId(bookRecord));
         // 책갈피 하나 더 추가
-        bookmarkRepository.save(Bookmark.create(
+        testEntityManager.persist(Bookmark.create(
                 bookRecord,
                 "934db224-c79f-49c9-92ba-711154632176",
                 100,

--- a/server/src/test/java/com/codecozy/server/repository/BookmarkRepositoryTest.java
+++ b/server/src/test/java/com/codecozy/server/repository/BookmarkRepositoryTest.java
@@ -1,0 +1,206 @@
+package com.codecozy.server.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codecozy.server.entity.Book;
+import com.codecozy.server.entity.BookRecord;
+import com.codecozy.server.entity.Bookmark;
+import com.codecozy.server.entity.LocationList;
+import com.codecozy.server.entity.Member;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+class BookmarkRepositoryTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private BookRecordRepository bookRecordRepository;
+
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+
+    private final String isbn = "9791190090018";
+    private final String uuid = "b1526767-b6bc-427e-9f11-825ed2084cc8";
+
+    private Long memberId;
+    private Long locationId;
+
+    @BeforeEach
+    void setup() {
+        // 유저, 책 세팅
+        Member member = memberRepository.save(Member.create("이름", "01"));
+        memberId = member.getMemberId();
+        Book book = bookRepository.save(Book.create(
+                isbn,
+                "http://example.com/cover.jpg",
+                "제목",
+                "작가",
+                "과학",
+                300,
+                "출판사",
+                LocalDate.now()));
+
+        // 위치 세팅
+        LocationList location = locationRepository.save(LocationList.create(
+                "학교",
+                "서울시",
+                52,
+                62));
+        locationId = location.getLocationId();
+
+        // 독서노트 생성
+        BookRecord bookRecord = bookRecordRepository.save(BookRecord.create(member, book));
+
+        // 책갈피 추가 (3개)
+        bookmarkRepository.save(Bookmark.create(
+                bookRecord,
+                uuid,
+                10,
+                location,
+                LocalDate.of(2024, 12, 1)));
+        bookmarkRepository.save(Bookmark.create(
+                bookRecord,
+                "1a7599b0-a79b-4410-b2ce-d03a6a4c9bb9",
+                25,
+                location,
+                LocalDate.of(2024, 12, 5)));
+        bookmarkRepository.save(Bookmark.create(
+                bookRecord,
+                "05e1dcbc-e630-41ec-898a-1b22474fbb78",
+                50,
+                location,
+                LocalDate.of(2024, 12, 12)));
+
+        // DB 동기화 및 영속성 컨텍스트 초기화
+        testEntityManager.flush();
+        testEntityManager.clear();
+    }
+
+    @Test
+    @DisplayName("독서노트(부모) 삭제 시 책갈피(자식)가 삭제된다")
+    void deleteTest() {
+        // given
+        Member member = memberRepository.findByMemberId(memberId);
+        Book book = bookRepository.findByIsbn(isbn);
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
+        // when
+        bookRecordRepository.delete(bookRecord);
+
+        // then
+        // 부모 삭제 확인
+        assertThat(bookRecordRepository.findByMemberAndBook(member, book)).isNull();
+        // 자식 삭제 확인
+        assertThat(bookmarkRepository.findAllByBookRecord(bookRecord)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("특정 독서노트와 uuid로 책갈피 찾기")
+    void findByBookRecordAndUuid() {
+        // given
+        Member member = memberRepository.findByMemberId(memberId);
+        Book book = bookRepository.findByIsbn(isbn);
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
+        // when
+        Bookmark bookmark = bookmarkRepository.findByBookRecordAndUuid(bookRecord, uuid);
+
+        // then
+        assertThat(bookmark.getBookRecord().getMember()).isEqualTo(member);
+        assertThat(bookmark.getMarkPage()).isEqualTo(10);
+        assertThat(bookmark.getDate()).isEqualTo(LocalDate.of(2024, 12, 1));
+    }
+
+    @Test
+    @DisplayName("특정 유저의 모든 책갈피 찾기")
+    void findAllByBookRecordMember() {
+        // given
+        Member member = memberRepository.findByMemberId(memberId);
+
+        // when
+        List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecordMember(member);
+
+        // then
+        assertThat(bookmarks).hasSize(3);
+        assertThat(bookmarks).extracting(Bookmark::getMarkPage)
+                             .containsExactlyInAnyOrder(10, 25, 50);
+    }
+
+    @Test
+    @DisplayName("특정 독서노트의 모든 책갈피 찾기")
+    void findAllByBookRecord() {
+        // given
+        Member member = memberRepository.findByMemberId(memberId);
+        Book book = bookRepository.findByIsbn(isbn);
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
+        // when
+        List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecord(bookRecord);
+
+        // then
+        assertThat(bookmarks).hasSize(3);
+        assertThat(bookmarks).extracting(Bookmark::getMarkPage)
+                             .containsExactlyInAnyOrder(10, 25, 50);
+    }
+
+    @Test
+    @DisplayName("특정 유저, 특정 위치에 있는 모든 책갈피 찾기")
+    void findAllByBookRecordMemberAndLocationList() {
+        // given
+        Member member = memberRepository.findByMemberId(memberId);
+        LocationList location = locationRepository.findByLocationId(locationId);
+
+        // when
+        List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecordMemberAndLocationList(
+                member, location);
+
+        // then
+        assertThat(bookmarks).hasSize(3);
+        assertThat(bookmarks).extracting(Bookmark::getMarkPage)
+                             .containsExactlyInAnyOrder(10, 25, 50);
+    }
+
+    @Test
+    @DisplayName("특정 독서노트의 최근 책갈피 3개 불러오기")
+    void findTop3ByBookRecordOrderByDateDesc() {
+        // given
+        Member member = memberRepository.findByMemberId(memberId);
+        Book book = bookRepository.findByIsbn(isbn);
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+        LocationList location = locationRepository.findByLocationId(locationId);
+        // 책갈피 하나 더 추가
+        bookmarkRepository.save(Bookmark.create(
+                bookRecord,
+                "934db224-c79f-49c9-92ba-711154632176",
+                100,
+                location,
+                LocalDate.of(2024, 12, 20)));
+
+        // when
+        List<Bookmark> bookmarks = bookmarkRepository.findTop3ByBookRecordOrderByDateDesc(
+                bookRecord);
+
+        // then
+        assertThat(bookmarks).hasSize(3);
+        assertThat(bookmarks).extracting(Bookmark::getMarkPage)
+                             .containsExactlyInAnyOrder(25, 50, 100);
+    }
+}

--- a/server/src/test/java/com/codecozy/server/repository/MemoRepositoryTest.java
+++ b/server/src/test/java/com/codecozy/server/repository/MemoRepositoryTest.java
@@ -1,0 +1,164 @@
+package com.codecozy.server.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codecozy.server.entity.Book;
+import com.codecozy.server.entity.BookRecord;
+import com.codecozy.server.entity.Member;
+import com.codecozy.server.entity.Memo;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+class MemoRepositoryTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private BookRecordRepository bookRecordRepository;
+
+    @Autowired
+    private MemoRepository memoRepository;
+
+    private final String isbn = "9791190090018";
+    private final String uuid = "b1526767-b6bc-427e-9f11-825ed2084cc8";
+
+    private Long memberId;
+
+    @BeforeEach
+    void setup() {
+        // 유저, 책 세팅
+        Member member = memberRepository.save(Member.create("이름", "01"));
+        memberId = member.getMemberId();
+        Book book = bookRepository.save(Book.create(
+                isbn,
+                "http://example.com/cover.jpg",
+                "제목",
+                "작가",
+                "과학",
+                300,
+                "출판사",
+                LocalDate.now()));
+
+        // 독서노트 생성
+        BookRecord bookRecord = bookRecordRepository.save(BookRecord.create(member, book));
+
+        // 메모 추가
+        memoRepository.save(Memo.create(
+                bookRecord,
+                uuid,
+                10,
+                LocalDate.of(2024, 12, 1),
+                "인상깊음"));
+
+        // DB 동기화 및 영속성 컨텍스트 초기화
+        testEntityManager.flush();
+        testEntityManager.clear();
+    }
+
+    // 유저, 책 정보로 독서노트 객체를 가져오는 함수
+    BookRecord getBookRecord() {
+        Member member = memberRepository.findByMemberId(memberId);
+        Book book = bookRepository.findByIsbn(isbn);
+
+        return bookRecordRepository.findByMemberAndBook(member, book);
+    }
+
+    @Test
+    @DisplayName("독서노트(부모) 삭제 시 메모(자식)가 삭제된다")
+    void deleteTest() {
+        // given
+        Member member = memberRepository.findByMemberId(memberId);
+        Book book = bookRepository.findByIsbn(isbn);
+        BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
+
+        // when
+        bookRecordRepository.delete(bookRecord);
+
+        // then
+        // 부모 삭제 확인
+        assertThat(bookRecordRepository.findByMemberAndBook(member, book)).isNull();
+        // 자식 삭제 확인
+        assertThat(memoRepository.findByBookRecordAndUuid(bookRecord, uuid)).isNull();
+    }
+
+    @Test
+    @DisplayName("독서노트 객체와 uuid 값으로 메모 한 개를 찾는다")
+    void findByBookRecordAndUuid() {
+        // given
+        BookRecord bookRecord = getBookRecord();
+
+        // when
+        Memo find = memoRepository.findByBookRecordAndUuid(bookRecord, uuid);
+
+        // then
+        assertThat(find).isNotNull();
+        assertThat(find.getMemoText()).isEqualTo("인상깊음");
+        assertThat(find.getBookRecord().getMember().getNickname()).isEqualTo("이름");
+    }
+
+    @Test
+    @DisplayName("특정 독서노트 내에 있는 모든 메모를 찾는다")
+    void findAllByBookRecord() {
+        // given
+        BookRecord bookRecord = getBookRecord();
+
+        // 메모 하나 더 추가
+        memoRepository.save(Memo.create(
+                bookRecord,
+                "c1526767-b6bc-427e-9f11-825ed2084cc8",
+                50,
+                LocalDate.of(2024, 12, 5),
+                "이러쿵저러쿵"));
+
+        // when
+        List<Memo> findList = memoRepository.findAllByBookRecord(bookRecord);
+
+        // then
+        assertThat(findList).hasSize(2);
+        assertThat(findList).extracting(Memo::getMemoText)
+                            .containsExactlyInAnyOrder("인상깊음", "이러쿵저러쿵");
+    }
+
+    @Test
+    @DisplayName("특정 독서노트 내에 작성한 최근 3개의 메모를 찾는다")
+    void findTop3ByBookRecordOrderByDateDesc() {
+        // given
+        BookRecord bookRecord = getBookRecord();
+
+        // 메모 2개 추가
+        memoRepository.save(Memo.create(
+                bookRecord,
+                "c1526767-b6bc-427e-9f11-825ed2084cc8",
+                50,
+                LocalDate.of(2024, 12, 5),
+                "이러쿵저러쿵"));
+        memoRepository.save(Memo.create(
+                bookRecord,
+                "d1526767-b6bc-427e-9f11-825ed2084cc8",
+                100,
+                LocalDate.of(2024, 12, 10),
+                "샬라샬라"));
+
+        // when
+        List<Memo> findList = memoRepository.findTop3ByBookRecordOrderByDateDesc(bookRecord);
+
+        // then
+        assertThat(findList).hasSize(3);
+        assertThat(findList).extracting(Memo::getMarkPage)
+                            .containsExactly(100, 50, 10);
+    }
+}

--- a/server/src/test/java/com/codecozy/server/repository/PersonalDictionaryRepositoryTest.java
+++ b/server/src/test/java/com/codecozy/server/repository/PersonalDictionaryRepositoryTest.java
@@ -1,0 +1,142 @@
+package com.codecozy.server.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codecozy.server.entity.Book;
+import com.codecozy.server.entity.BookRecord;
+import com.codecozy.server.entity.Member;
+import com.codecozy.server.entity.PersonalDictionary;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+class PersonalDictionaryRepositoryTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private BookRecordRepository bookRecordRepository;
+
+    @Autowired
+    private PersonalDictionaryRepository personalDictionaryRepository;
+
+    private Member member;
+    private Book book;
+    private BookRecord bookRecord;
+
+    @BeforeEach
+    void setup() {
+        // 유저, 책, 독서노트 세팅
+        member = testEntityManager.persist(Member.create("이름", "01"));
+        book = testEntityManager.persist(Book.create(
+                "9791190090018",
+                "http://example.com/cover.jpg",
+                "제목",
+                "작가",
+                "과학",
+                300,
+                "출판사",
+                LocalDate.now()));
+        bookRecord = testEntityManager.persist(BookRecord.create(member, book));
+
+        // 인물사전 1개 추가
+        testEntityManager.persist(PersonalDictionary.create(
+                bookRecord,
+                "토마토",
+                123456,
+                "멋쟁이 토마토",
+                "토마토는 방울토마토였을까 왕토마토였을까 미스테리한 점이 돋보인다"));
+
+        // DB 반영 및 영속성 컨텍스트 초기화
+        testEntityManager.flush();
+        testEntityManager.clear();
+    }
+
+    @Test
+    @DisplayName("독서노트(부모)를 삭제하면 인물사전(자식)도 삭제된다")
+    void deleteTest() {
+        // given
+        BookRecord foundBookRecord = testEntityManager.find(BookRecord.class,
+                testEntityManager.getId(bookRecord));
+
+        // when
+        testEntityManager.remove(foundBookRecord);
+
+        // then
+        // 부모 삭제 확인
+        assertThat(bookRecordRepository.findByMemberAndBook(member, book)).isNull();
+        // 자식 삭제 확인
+        assertThat(personalDictionaryRepository.findAllByBookRecord(bookRecord)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("독서노트와 이름으로 인물사전을 찾는다")
+    void findByBookRecordAndName() {
+        // when
+        PersonalDictionary found = personalDictionaryRepository.findByBookRecordAndName(bookRecord,
+                "토마토");
+
+        // then
+        assertThat(found.getEmoji()).isEqualTo(123456);
+        assertThat(found.getPreview()).isEqualTo("멋쟁이 토마토");
+    }
+
+    @Test
+    @DisplayName("특정 독서노트 내에 있는 모든 인물사전을 찾는다")
+    void findAllByBookRecord() {
+        // given
+        bookRecord = testEntityManager.find(BookRecord.class, testEntityManager.getId(bookRecord));
+        // 인물사전 1개 더 추가
+        testEntityManager.persist(PersonalDictionary.create(
+                bookRecord,
+                "당근",
+                789123,
+                "당근당근",
+                "귀여운 면이 있는 친구다"));
+
+        // when
+        List<PersonalDictionary> foundList = personalDictionaryRepository.findAllByBookRecord(
+                bookRecord);
+
+        // then
+        assertThat(foundList).hasSize(2);
+        assertThat(foundList).extracting(PersonalDictionary::getName)
+                             .containsExactlyInAnyOrder("토마토", "당근");
+    }
+
+    @Test
+    @DisplayName("독서노트 내에 있는 모든 인물사전 중 이름순(오름차순)으로 3개 불러온다")
+    void findTop3ByBookRecordOrderByNameAsc() {
+        // given
+        bookRecord = testEntityManager.find(BookRecord.class, testEntityManager.getId(bookRecord));
+        // 인물사전 2개 더 추가
+        testEntityManager.persist(PersonalDictionary.create(
+                bookRecord,
+                "당근",
+                789123,
+                "당근당근",
+                "귀여운 면이 있는 친구다"));
+        testEntityManager.persist(PersonalDictionary.create(
+                bookRecord,
+                "오이",
+                456789,
+                "오이오이..!!",
+                "할 말은 하는 성격"));
+
+        // when
+        List<PersonalDictionary> foundList = personalDictionaryRepository.findTop3ByBookRecordOrderByNameAsc(
+                bookRecord);
+
+        // then
+        assertThat(foundList).hasSize(3);
+        assertThat(foundList).extracting(PersonalDictionary::getName)
+                             .containsExactly("당근", "오이", "토마토");
+    }
+}

--- a/server/src/test/java/com/codecozy/server/service/BookServiceTest.java
+++ b/server/src/test/java/com/codecozy/server/service/BookServiceTest.java
@@ -60,8 +60,8 @@ public class BookServiceTest {
         when(bookRecordDateRepository.findByBookRecord(bookRecord)).thenReturn(bookRecordDate);
 
         // 북마크 데이터
-        Bookmark bookmark = Bookmark.create(member, book, "3b7d", 50, null, LocalDate.of(2024, 12, 10));
-        when(bookmarkRepository.findByMemberAndBookAndUuid(member, book, "3b7d")).thenReturn(bookmark);
+        Bookmark bookmark = Bookmark.create(bookRecord, "3b7d", 50, null, LocalDate.of(2024, 12, 10));
+        when(bookmarkRepository.findByBookRecordAndUuid(bookRecord, "3b7d")).thenReturn(bookmark);
     }
 
     @AfterEach


### PR DESCRIPTION
## 목적🎯
- `Bookmark`(책갈피), `Memo`(메모), `Personal Dictionary`(인물사전) Entity의 연관관계 재설정
- 일부 불필요한 코드 제거
- 코드 가독성 향상

## 변경사항🛠️
- **Bookmark, Memo, Personal Dictionary 관련 변경사항**
  - Entity 연관관계 수정
    - 위 해당 객체가 더 이상 `Member`, `Book` 객체를 직접적으로 참조하지 않습니다.
    - 대신에 `BookRecord`(독서노트)의 기본 키를 참조하도록 수정했습니다.
    - 생성 메소드인 `create()`를 수정했습니다.
    - 변경된 `create()`에 맞추어  `BookService` 내 코드를 수정했습니다.
  - Repository 수정
    - Repository 내 메소드가 무슨 역할을 하는지 한 눈에 알아볼 수 있도록 주석을 추가했습니다.
    - 연관관계 수정에 따라 각 메소드에도 변경사항을 반영하였습니다.
    - 변경된 메소드에 맞추어 `BookService`, `BookServiceTest` 내 코드를 수정했습니다.
- **기타 변경사항**
  - `LocationList` 내 사용하지 않는 `setter` 메소드를 발견해 삭제했습니다.

## 수행한 테스트✏️
- **공통**
  - 부모 객체(`BookRecord`)를 삭제했을 때, 자식 객체(`Bookmark`, `Memo`, `Personal Dictionary`)도 연쇄적으로 삭제된다
- **Bookmark 관련 테스트**
  - 특정 독서노트와 uuid로 책갈피를 찾는다
  - 특정 유저의 모든 책갈피를 찾는다
  - 특정 독서노트의 모든 책갈피를 찾는다
  - 특정 유저, 특정 위치에 있는 모든 책갈피를 찾는다
  - 특정 독서노트의 최근 책갈피 3개를 불러온다
- **Memo 관련 테스트**
  - 특정 독서노트 내에서 uuid 값으로 메모를 찾는다
  - 특정 독서노트 내에 있는 모든 메모를 찾는다
  - 특정 독서노트 내에 작성한 최근 3개의 메모를 찾는다
- **Personal Dictionary 관련 테스트**
  - 독서노트와 이름으로 인물(사전)을 찾는다
  - 특정 독서노트 내에 있는 모든 인물(사전)을 찾는다
  - 독서노트 내에 있는 모든 인물(사전) 중 이름순(오름차순)으로 3개 불러온다

## 비고📌
이로써 DB 연관관계 재설정이 모두 끝났습니다!
궁금한 점이 있다면 편하게 질문해주세요 :D