### PR TITLE
테스트 코드 추가 및 조회 API 리팩토링

### DIFF
--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -14,10 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.slf4j.spi.LocationAwareLogger;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.yaml.snakeyaml.Yaml;
 

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1717,15 +1717,16 @@ public class BookService {
         // 사용자 받아오기
         Member member = memberRepository.findByMemberId(memberId);
 
+        // 사용자별 등록 위치 받아오기
         List<MemberLocation> memberLocationList = memberLocationRepository.findAllByMember(member);
         for (MemberLocation value : memberLocationList) {
             LocationList memberLocation = value.getLocationList();
 
-            if (memberLocation != null) {
+            //if (memberLocation != null) {
                 // 응답으로 보낼 객체에 추가
                 location.add(new RecentLocationResponse(memberLocation.getLocationId(), memberLocation.getPlaceName(),
                         memberLocation.getAddress(), memberLocation.getLatitude(), memberLocation.getLongitude()));
-            }
+            //}
         }
 
         if (location.isEmpty()) {
@@ -1782,6 +1783,7 @@ public class BookService {
         Member member = memberRepository.findByMemberId(memberId);
 
         // 반환 리스트(두 스트림에서 검색하고 리스트로 병합)
+        // 각각 독서노트와 책갈피에서 검색한 결과로 스트림을 만들어 위치아이디, 위도, 경도, locationType을 map에 담아 병합하여 리스트 생성
         List<AllMarkerResponse> allMarkers = Stream.concat(
                 bookRecordRepository.findAllByMember(member).stream()
                         .map(bookRecord -> new AllMarkerResponse(
@@ -1900,6 +1902,7 @@ public class BookService {
                 bookmark = (Bookmark) records.get(i);
                 if (bookmark.getLocationList() == null) break;
 
+                // 책갈피에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
                 date = converterService.dateToString(bookmark.getDate());
                 title = bookmark.getBookRecord().getBook().getTitle();
                 readPage = bookmark.getMarkPage();
@@ -1910,6 +1913,7 @@ public class BookService {
                 bookRecord = (BookRecord) records.get(i);
                 if (bookRecord.getLocationList() == null) break;
 
+                // 독서노트에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
                 date = converterService.dateToString(bookRecord.getStartDate());
                 title = bookRecord.getBook().getTitle();
                 readPage = bookRecord.getMarkPage();
@@ -1917,6 +1921,7 @@ public class BookService {
                 placeName = bookRecord.getLocationList().getPlaceName();
             }
 
+            // 받아온 정보로 위치 정보 추가
             locationInfo.add(new LocationInfoDto(date, isBookmark, title, readPage, locationId, placeName));
         }
     }
@@ -1950,6 +1955,7 @@ public class BookService {
                 bookmark = (Bookmark) records.get(i);
                 if (bookmark.getLocationList() == null) break;
 
+                // 책갈피에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
                 date = converterService.dateToString(bookmark.getDate());
                 title = bookmark.getBookRecord().getBook().getTitle();
                 readPage = bookmark.getMarkPage();
@@ -1960,6 +1966,7 @@ public class BookService {
                 bookRecord = (BookRecord) records.get(i);
                 if (bookRecord.getLocationList() == null) break;
 
+                // 독서노트에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
                 date = converterService.dateToString(bookRecord.getStartDate());
                 title = bookRecord.getBook().getTitle();
                 readPage = bookRecord.getMarkPage();
@@ -1967,6 +1974,7 @@ public class BookService {
                 placeName = bookRecord.getLocationList().getPlaceName();
             }
 
+            // 받아온 정보로 위치 정보 추가
             locationInfo.add(new LocationInfoDto(date, isBookmark, title, readPage, locationId, placeName));
         }
     }
@@ -2002,6 +2010,7 @@ public class BookService {
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
         urlConnection.setRequestMethod("GET");
 
+        // 응답 데이터를 받아올 버퍼 생성
         // try-with-resources (버퍼를 명시적으로 close 하지 않고, 간결하게 처리하기 위함)
         try (BufferedReader br = new BufferedReader(new InputStreamReader(urlConnection.getInputStream(), StandardCharsets.UTF_8))) {
             String returnLine;

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1723,12 +1723,14 @@ public class BookService {
         for (MemberLocation value : memberLocationList) {
             LocationList memberLocation = value.getLocationList();
 
-            // 응답으로 보낼 객체에 추가
-            location.add(new RecentLocationResponse(memberLocation.getLocationId(), memberLocation.getPlaceName(),
-                    memberLocation.getAddress(), memberLocation.getLatitude(), memberLocation.getLongitude()));
+            if (memberLocation != null) {
+                // 응답으로 보낼 객체에 추가
+                location.add(new RecentLocationResponse(memberLocation.getLocationId(), memberLocation.getPlaceName(),
+                        memberLocation.getAddress(), memberLocation.getLatitude(), memberLocation.getLongitude()));
+            }
         }
 
-        if (location.size() <= 0) {
+        if (location.isEmpty()) {
             return new ResponseEntity<>(
                     DefaultResponse.from(StatusCode.NOT_FOUND, "조회할 위치가 없습니다."),
                     HttpStatus.NOT_FOUND);

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1410,26 +1410,18 @@ public class BookService {
 
         // 한 유저의 한 책에 대한 메모 전체 검색
         List<Memo> memos = memoRepository.findAllByBookRecord(bookRecord);
-        for (int i = 0; i < memos.size(); i++) {
-            Memo memo = memos.get(i);
+        for(Memo memo : memos) {
+            String dateStr = converterService.dateToString(memo.getDate());
 
-            // 종이책이면
-            if (bookRecordRepository.findByMemberAndBook(member, book).getBookType() == 0) {
-                // 페이지 -> 퍼센트 계산
+            // 종이책이면 페이지 -> 퍼센트 계산
+            if (bookRecord.getBookType() == 0) {
                 int percent = (int) Math.round(100.0 * memo.getMarkPage() / book.getTotalPage());
-
                 // 응답으로 보낼 내용에 더하기
-                String dateStr = converterService.dateToString(memo.getDate());
-                memoList.add(
-                        new MemoResponse(dateStr, memo.getMarkPage(), percent, memo.getMemoText(), memo.getUuid()));
+                memoList.add(new MemoResponse(dateStr, memo.getMarkPage(), percent, memo.getMemoText(), memo.getUuid()));
             } else { // 전자책, 오디오북이면 퍼센트 -> 페이지 계산
-                // 페이지 -> 퍼센트 계산
                 int page = (int) Math.round(book.getTotalPage() / 100.0 / memo.getMarkPage());
-
                 // 응답으로 보낼 내용에 더하기
-                String dateStr = converterService.dateToString(memo.getDate());
-                memoList.add(
-                        new MemoResponse(dateStr, page, memo.getMarkPage(), memo.getMemoText(), memo.getUuid()));
+                memoList.add(new MemoResponse(dateStr, page, memo.getMarkPage(), memo.getMemoText(), memo.getUuid()));
             }
         }
 

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1414,11 +1414,11 @@ public class BookService {
 
             // 종이책이면 페이지 -> 퍼센트 계산
             if (bookRecord.getBookType() == 0) {
-                int percent = (int) Math.round(100.0 * memo.getMarkPage() / book.getTotalPage());
+                int percent = converterService.pageToPercent(memo.getMarkPage(), book.getTotalPage());
                 // 응답으로 보낼 내용에 더하기
                 memoList.add(new MemoResponse(dateStr, memo.getMarkPage(), percent, memo.getMemoText(), memo.getUuid()));
             } else { // 전자책, 오디오북이면 퍼센트 -> 페이지 계산
-                int page = (int) Math.round(book.getTotalPage() / 100.0 / memo.getMarkPage());
+                int page = converterService.percentToPage(memo.getMarkPage(), book.getTotalPage());
                 // 응답으로 보낼 내용에 더하기
                 memoList.add(new MemoResponse(dateStr, page, memo.getMarkPage(), memo.getMemoText(), memo.getUuid()));
             }
@@ -1665,11 +1665,11 @@ public class BookService {
             // 종이책이면
             if (bookRecord.getBookType() == 0) {
                 // 페이지 -> 퍼센트 계산
-                int percent = (int) Math.round(100.0 * markPage / book.getTotalPage());
+                int percent = converterService.pageToPercent(markPage, book.getTotalPage());
                 bookmarkList.add(new BookmarkResponse(dateStr, markPage, percent, location, bookmark.getUuid()));
             } else { // 전자책, 오디오북이면
                 // 퍼센트 -> 페이지 계산
-                int page = (int) Math.round(book.getTotalPage() / 100.0 / markPage);
+                int page = converterService.percentToPage(markPage, book.getTotalPage());
                 bookmarkList.add(new BookmarkResponse(dateStr, page, markPage, location, bookmark.getUuid()));
             }
         }

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import org.slf4j.spi.LocationAwareLogger;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.parameters.P;
@@ -1873,81 +1874,29 @@ public class BookService {
         Member member = memberRepository.findByMemberId(memberId);
 
         int orderNumber = request.orderNumber();
-
-        // Response 전달 시 들어가는 데이터
-        String date;
-        String title;
-        int readPage;
         long locationId = request.locationId();
-        String placeName;
-        boolean isBookRecordEnd = false;
-        boolean isBookmarkEnd = false;
+
+        // 조회할 위치가 더 있는지에 대한 flag
+        BooleanWrapper isBookRecordEnd = new BooleanWrapper();
+        isBookRecordEnd.setValue(false);
+        BooleanWrapper isBookmarkEnd = new BooleanWrapper();
+        isBookmarkEnd.setValue(false);
 
         // locationId로 위치 정보 검색
         LocationList locationList = locationRepository.findByLocationId(locationId);
 
-        // 독서노트(대표위치)에서 해당 위치 검색
-        List<BookRecord> bookRecords = bookRecordRepository.findAllByMemberAndLocationList(member, locationList);
-        int size = bookRecords.size();
-        BookRecord bookRecord;
-        for (int i = (orderNumber * 20); i < 20 + (orderNumber * 20); i++) {
-            // 이번이 독서노트 마지막 조회면 (전체 개수와 이번 orderNumber를 사용하여 비교)
-            if ((orderNumber + 1) * 20 >= size) isBookRecordEnd = true;
+        // 독서노트, 북마크에서 위치 정보를 가져오는 메소드 호출
+        addLocations(member, locationList, orderNumber, false, locationInfo, isBookRecordEnd);
+        addLocations(member, locationList, orderNumber, true, locationInfo, isBookmarkEnd);
 
-            // 현재 조회하는 컬럼이 받아온 컬럼들의 사이즈보다 같거나 크면 break
-            if (i >= size) {
-                break;
-            }
-
-            bookRecord = bookRecords.get(i);
-            if (bookRecord.getLocationList() == null) {
-                break;
-            }
-
-            date = converterService.dateToString(bookRecord.getStartDate());
-            title = bookRecord.getBook().getTitle();
-            readPage = bookRecord.getMarkPage();
-            locationId = bookRecord.getLocationList().getLocationId();
-            placeName = bookRecord.getLocationList().getPlaceName();
-
-            locationInfo.add(new LocationInfoDto(date, false, title, readPage, locationId, placeName));
-        }
-
-        // 책갈피에서 해당 위치 검색
-        List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecordMemberAndLocationList(member, locationList);
-        size = bookmarks.size();
-        Bookmark bookmark;
-        for (int i = (orderNumber * 20); i < 20 + (orderNumber * 20); i++) {
-            // 이번이 책갈피 마지막 조회면 (전체 개수와 이번 orderNumber를 사용하여 비교)
-            if ((orderNumber + 1) * 20 >= size) isBookmarkEnd = true;
-
-            // 현재 조회하는 컬럼이 받아온 컬럼들의 사이즈보다 같거나 크면 break
-            if (i >= size) {
-                break;
-            }
-
-            bookmark = bookmarks.get(i);
-            if (bookmark.getLocationList() == null) {
-                break;
-            }
-
-            date = converterService.dateToString(bookmark.getDate());
-            title = bookmark.getBookRecord().getBook().getTitle();
-            readPage = bookmark.getMarkPage();
-            locationId = bookmark.getLocationList().getLocationId();
-            placeName = bookmark.getLocationList().getPlaceName();
-
-            locationInfo.add(new LocationInfoDto(date, true, title, readPage, locationId, placeName));
-        }
-
-        if (locationInfo.size() <= 0) { // 세부 조회할 마크가 하나도 없는 경우
+        if (locationInfo.isEmpty()) { // 세부 조회할 마크가 하나도 없는 경우
             return new ResponseEntity<>(
                     DefaultResponse.from(StatusCode.NOT_FOUND, "세부 조회할 마크가 없습니다."),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", new AllLocationResponse(locationInfo, (isBookRecordEnd && isBookmarkEnd))),
+                DefaultResponse.from(StatusCode.OK, "성공", new AllLocationResponse(locationInfo, (isBookRecordEnd.getValue() && isBookmarkEnd.getValue()))),
                 HttpStatus.OK);
     }
 
@@ -1976,6 +1925,63 @@ public class BookService {
         }
 
         memberLocationRepository.save(MemberLocation.create(member, locationList, LocalDateTime.now()));
+    }
+
+    // 마크 세부 조회를 위한 독서노트, 책갈피에서의 위치 정보 조회
+    public void addLocations(Member member, LocationList locationList, int orderNumber, boolean isBookmark, List<LocationInfoDto> locationInfo, BooleanWrapper isEnd) {
+        // 북마크인지 여부에 따라 필요한 레포지토리 검색
+        List<?> records = isBookmark ? bookmarkRepository.findAllByBookRecordMemberAndLocationList(member, locationList) : bookRecordRepository.findAllByMemberAndLocationList(member, locationList);
+
+        int size = records.size();
+        BookRecord bookRecord;
+        Bookmark bookmark;
+
+        for (int i = (orderNumber * 20); i < 20 + (orderNumber * 20); i++) {
+            // 이번이 마지막 조회면 (전체 개수와 이번 orderNumber를 사용하여 비교)
+            if ((orderNumber + 1) * 20 >= size) isEnd.setValue(true);
+
+            // 현재 조회하는 컬럼이 받아온 컬럼들의 사이즈보다 같거나 크면 break
+            if (i >= size) {
+                break;
+            }
+
+            // Response 전달 시 들어가는 데이터
+            String date;
+            String title;
+            int readPage;
+            long locationId;
+            String placeName;
+
+            if (isBookmark) { // 책갈피면
+                bookmark = (Bookmark) records.get(i);
+                if (bookmark.getLocationList() == null) break;
+
+                date = converterService.dateToString(bookmark.getDate());
+                title = bookmark.getBookRecord().getBook().getTitle();
+                readPage = bookmark.getMarkPage();
+                locationId = bookmark.getLocationList().getLocationId();
+                placeName = bookmark.getLocationList().getPlaceName();
+
+            } else { // 독서노트면
+                bookRecord = (BookRecord) records.get(i);
+                if (bookRecord.getLocationList() == null) break;
+
+                date = converterService.dateToString(bookRecord.getStartDate());
+                title = bookRecord.getBook().getTitle();
+                readPage = bookRecord.getMarkPage();
+                locationId = bookRecord.getLocationList().getLocationId();
+                placeName = bookRecord.getLocationList().getPlaceName();
+            }
+
+            locationInfo.add(new LocationInfoDto(date, false, title, readPage, locationId, placeName));
+        }
+    }
+
+    // Boolean을 참조 타입으로 전달하기 위한 클래스
+    public class BooleanWrapper {
+        private boolean value;
+        public boolean getValue() { return value; }
+        public void setValue(boolean value) { this.value = value; }
     }
 
     // 한줄평에 대한 반응 레코드 등록(BookReviewReaction)

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1780,8 +1780,7 @@ public class BookService {
         // 사용자 받아오기
         Member member = memberRepository.findByMemberId(memberId);
 
-        // 반환 리스트(두 스트림에서 검색하고 리스트로 병합)
-        // 각각 독서노트와 책갈피에서 검색한 결과로 스트림을 만들어 위치아이디, 위도, 경도, locationType을 map에 담아 병합하여 리스트 생성
+        // 독서노트의 대표위치, 책갈피의 위치를 가져와 리스트 생성
         List<AllMarkerResponse> allMarkers = Stream.concat(
                 bookRecordRepository.findAllByMember(member).stream()
                         .map(bookRecord -> new AllMarkerResponse(

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1722,11 +1722,9 @@ public class BookService {
         for (MemberLocation value : memberLocationList) {
             LocationList memberLocation = value.getLocationList();
 
-            //if (memberLocation != null) {
-                // 응답으로 보낼 객체에 추가
-                location.add(new RecentLocationResponse(memberLocation.getLocationId(), memberLocation.getPlaceName(),
-                        memberLocation.getAddress(), memberLocation.getLatitude(), memberLocation.getLongitude()));
-            //}
+            // 응답으로 보낼 객체에 추가
+            location.add(new RecentLocationResponse(memberLocation.getLocationId(), memberLocation.getPlaceName(),
+                    memberLocation.getAddress(), memberLocation.getLatitude(), memberLocation.getLongitude()));
         }
 
         if (location.isEmpty()) {


### PR DESCRIPTION
## 목적🎯
- 이전에 진행한 메모 등록, 메모 수정 API 변경과 관련된 테스트 코드 작성
-  조회 API에서 불필요한 코드나 반복적인 코드 정리

## 변경사항🛠️
1. 메모 등록, 메모 수정 시 recentDate가 업데이트 되었는지 확인하기 위한 테스트 캡쳐 및 검증
2. 도서 정보 초기 조회 API에서 기능별 메소드 분리, 스트림과 람다식을 사용하여 반복문 내 코드 최소화, try-with-resources를 사용하여 버퍼 리소스 누수 방지 진행
3. 지도 마크 조회 API에서 스트림의 concat을 이용해 위치 정보 추출과 변환 통합
4. 책갈피 전체 조회 API에서 중복되는 호출(markPage, dateStr) 개선
5. 메모 전체 조회 API에서 중복되는 호출(bookRecord 검색, dateStr) 개선
6. 마크 세부 조회 API에서 기능별 메소드 분리, 중복되는 코드 개선
7. 전체 위치 조회 API에서 기능별 메소드 분리, 중복되는 코드 개선(변경사항 6번과 동일)
8. 최근 등록 위치 조회 API에서 null 체크 코드 추가
9. 사용하지 않는 모듈 삭제

## 수행한 테스트✏️
- 메모 등록, 메모 수정 시 recentDate가 업데이트 되었는지 확인하는 테스트 코드 진행(변경사항 1번) 
- 수정한 조회 API는 Postman으로 테스트 진행
 -> 책 등록으로 위치 하나 추가한 후 지도 마크 조회
 -> 책갈피 하나 추가한 후 책갈피 전체 조회
 -> 메모 하나 추가한 후 메모 전체 조회
 -> 책 등록, 책갈피 추가로 위치 두 개 추가한 후 각각 마크 세부 조회
 -> 책 등록, 책갈피 추가로 위치 두 개 추가한 후 전체 위치 조회

## 비고📌
한 번에 올리니까 양이 꽤 길어졌네요....!!🫠 천천히 확인하시고 답장주세요!! 궁금한 부분 질문 주시면 가능한 빨리 답장 달아보겠습니다!!🩷