### PR TITLE
독서노트 조회 API 요구사항 추가 및 테스트 코드 리펙토링

### DIFF
--- a/server/src/main/java/com/codecozy/server/dto/response/GetReadingNoteResponse.java
+++ b/server/src/main/java/com/codecozy/server/dto/response/GetReadingNoteResponse.java
@@ -10,6 +10,7 @@ public record GetReadingNoteResponse(
         int totalPage,
         int readPage,
         int readingPercent,
+        String firstReviewDate,
         String keywordReview,
         String commentReview,
         List<Integer> selectReview,

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -146,6 +146,8 @@ public class BookService {
         int totalPage = book.getTotalPage();
         int readPage = bookRecord.getMarkPage();
         int readingPercent = converterService.pageToPercent(readPage, totalPage);
+        String firstReviewDate = bookRecord.getFirstReviewDate() != null ?
+                converterService.dateToString(bookRecord.getFirstReviewDate()) : null;
         String keywordReview = bookRecord.getKeyWord();
         String commentReview = null;
         try {
@@ -240,6 +242,7 @@ public class BookService {
                         totalPage,
                         readPage,
                         readingPercent,
+                        firstReviewDate,
                         keywordReview,
                         commentReview,
                         selectReview,

--- a/server/src/test/java/com/codecozy/server/entity/BookRecordTest.java
+++ b/server/src/test/java/com/codecozy/server/entity/BookRecordTest.java
@@ -1,0 +1,41 @@
+package com.codecozy.server.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class BookRecordTest {
+    @Test
+    @DisplayName("독서노트의 첫 리뷰 날짜 등록 테스트")
+    public void testFirstReviewDate() {
+        // given
+        LocalDate today = LocalDate.now();
+        BookRecord bookRecord = new BookRecord();
+
+        // when
+        bookRecord.setFirstReviewDate(today);
+
+        // then
+        assertThat(bookRecord.getFirstReviewDate())
+                .isBeforeOrEqualTo(today) // 오늘 날짜를 포함한 이전 날짜
+                .isNotNull(); // null 값이 아닌지 확인
+    }
+
+    @Test
+    @DisplayName("독서노트의 최근 수정 날짜(recentDate) 업데이트 테스트")
+    public void testUpdateRecentDate() {
+        // given
+        LocalDate testDay = LocalDate.of(2024, 12, 17);
+        BookRecord bookRecord = new BookRecord();
+
+        // when
+        bookRecord.setRecentDate(testDay);
+
+        // then
+        assertThat(bookRecord.getRecentDate())
+                .isEqualTo(testDay) // 테스트 날짜와 같은지
+                .isNotNull();
+    }
+}


### PR DESCRIPTION
## 목적🎯
- 책별 독서노트 조회 API 응답에 firstReviewDate(리뷰 최초 등록일) 추가
- BookServiceTest 리펙토링

## 변경사항🛠️
- 책별 독서노트 조회 API 응답에 `firstReviewDate` 필드를 추가했습니다.
- BookServiceTest 리펙토링
  - 기존 BookServiceTest가 통합 테스트로 진행되고 있던 것을 확인, 이를 단위 테스트로 변경했습니다.
    - `SpringBootTest`를 통해 `MockBean`을 스프링 컨텍스트에 등록하는 대신, `Mock`객체를 사용해서 이를 `InjectMocks`를 통해 주입하는 방식으로 변경했습니다.
    - Mock 객체만 사용함에 따라 `AfterEach` 메소드는 삭제했습니다.
  - 기존 BookServiceTest 내에 Entity 계층의 테스트가 포함되어 있어 이를 `BookRecordTest` 클래스로 분리했습니다.
  - 반복되거나, 자주 사용할 것 같은 부분과 동적 mock 설정 로직은 메소드로 분리하였습니다.
  - give절이 방대해지는 것을 예방하기 위해 `BeforeEach`에서 사용하는 mock 동작은 `lenient` 모드로 지정했습니다.
  - 응답 데이터의 json을 파싱해 오는 메소드를 추가했습니다.

## 수행한 테스트✏️
- 통합 테스트 -> 단위 테스트로 변경 후, 기존에 작성된 테스트가 성공하는지 확인
- 책별 독서노트 조회 API 응답에 `firstReviewDate` 필드를 추가한 건에 대한 테스트
  - firstReviewDate의 유무에 따라 정상적으로 돌아가는지에 대해 각각 테스트를 진행했습니다.