### PR TITLE
독서상태 변경 로직 추가 및 Response 메시지 리펙토링

### DIFF
--- a/server/src/main/java/com/codecozy/server/context/ResponseMessages.java
+++ b/server/src/main/java/com/codecozy/server/context/ResponseMessages.java
@@ -1,0 +1,75 @@
+package com.codecozy.server.context;
+
+public enum ResponseMessages {
+
+    SUCCESS("성공"),
+
+    // 토큰
+    EXPIRED_TOKEN("토큰이 만료되었습니다"),
+    NOT_FOUND_TOKEN("토큰이 존재하지 않습니다."),
+    INVALID_TOKEN_VALUE("토큰의 값이 유효하지 않습니다."),
+    INVALID_TOKEN_SIGNATURE("토큰의 서명이 올바르지 않습니다."),
+    INVALID_USER("(토큰 오류) 해당 유저가 존재하지 않습니다."),
+
+    // 사용자
+    OK_NICKNAME("사용 가능한 닉네임입니다."),
+    CONFLICT_NICKNAME("사용 불가능한 닉네임입니다."),
+
+    NOT_FOUND_USER("해당 사용자가 존재하지 않습니다."),
+    CONFLICT_USER("이미 가입한 회원입니다."),
+    INVALID_ID_TOKEN("ID 토큰이 유효하지 않습니다."),
+
+    // 독서노트
+    NOT_FOUND_BOOK_RECORD("해당 독서노트가 없습니다."),
+    CONFLICT_BOOK_RECORD("이미 등록한 독서노트입니다."),
+    CANNOT_REGISTER_BOOK_AS_WANT_TO_READ("독서 노트에 등록한 도서는 읽고 싶은 도서로 등록할 수 없습니다."),
+
+    // 위치
+    CONFLICT_MAIN_LOCATION("대표 위치가 이미 있습니다."),
+    NOT_FOUND_MAIN_LOCATION("해당 독서노트의 대표 위치가 없습니다."),
+
+    NOT_FOUND_LOCATION("조회할 위치가 없습니다."),
+    NOT_LATEST_LOCATION("최근 등록된 위치가 아닙니다."),
+    UNREGISTERED_LOCATION("등록되지 않은 위치입니다."),
+
+    NOT_FOUND_MARKER("조회할 마크가 없습니다."),
+    NOT_FOUND_MARKER_TO_DETAIL("세부 조회할 마크가 없습니다."),
+
+    // 리뷰
+    NOT_FOUND_REGISTERED_COMMENT("등록된 한줄평이 없습니다."),
+    CONFLICT_COMMENT("이미 등록한 한줄평입니다."),
+    NOT_FOUND_COMMENT("해당 한줄평이 없습니다."),
+
+    NOT_FOUND_COMMENT_REACTION("해당 한줄평에 남긴 반응이 없습니다."),
+    CONFLICT_REPORT("이미 신고한 리뷰입니다."),
+
+    CONFLICT_SELECT_REVIEW("이미 등록한 선택 리뷰입니다."),
+
+    // 책갈피
+    CONFLICT_BOOKMARK("이미 등록한 책갈피입니다."),
+    UNREGISTERED_BOOKMARK("등록하지 않은 책갈피입니다."),
+    NOT_FOUND_BOOKMARK("해당 책갈피가 없습니다."),
+
+    // 메모
+    CONFLICT_MEMO("이미 등록한 메모입니다."),
+    UNREGISTERED_MEMO("등록하지 않은 메모입니다."),
+    NOT_FOUND_MEMO("해당 메모가 없습니다."),
+
+    // 인물사전
+    CONFLICT_CHARACTER("이미 등록한 인물입니다."),
+    UNREGISTERED_CHARACTER("등록하지 않은 인물입니다."),
+    NOT_FOUND_CHARACTER("해당 인물이 없습니다."),
+
+    // 기타
+    MISSING_UUID("uuid 값이 없습니다.");
+
+    private final String message;
+
+    ResponseMessages(String message) {
+        this.message = message;
+    }
+
+    public String get() {
+        return message;
+    }
+}

--- a/server/src/main/java/com/codecozy/server/controller/BookController.java
+++ b/server/src/main/java/com/codecozy/server/controller/BookController.java
@@ -46,10 +46,10 @@ public class BookController {
     @PatchMapping("/readingStatus/{isbn}")
     public ResponseEntity modifyReadingStatus(@RequestHeader("xAuthToken") String token,
                                               @PathVariable("isbn") String isbn,
-                                              @RequestBody Map<String, Integer> readingStatusMap) {
+                                              @RequestBody ModifyReadingStatusRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
-        return bookService.modifyReadingStatus(memberId, isbn, readingStatusMap.get("readingStatus"));
+        return bookService.modifyReadingStatus(memberId, isbn, request);
     }
 
     // 소장여부 변경 API

--- a/server/src/main/java/com/codecozy/server/dto/request/ModifyReadingStatusRequest.java
+++ b/server/src/main/java/com/codecozy/server/dto/request/ModifyReadingStatusRequest.java
@@ -1,0 +1,6 @@
+package com.codecozy.server.dto.request;
+
+public record ModifyReadingStatusRequest(
+        int readingStatus,
+        String uuid
+) {}

--- a/server/src/main/java/com/codecozy/server/security/JwtAuthenticateFilter.java
+++ b/server/src/main/java/com/codecozy/server/security/JwtAuthenticateFilter.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.security;
 
+import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.context.StatusCode;
 import com.codecozy.server.dto.response.DefaultResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,26 +49,26 @@ public class JwtAuthenticateFilter extends OncePerRequestFilter {
 
             // 상태 코드 및 에러 메시지 세팅 (401)
             statusCode = StatusCode.UNAUTHORIZED;
-            exceptionMessage = "토큰이 만료되었습니다";
+            exceptionMessage = ResponseMessages.EXPIRED_TOKEN.get();
         } catch (IllegalArgumentException e) {
             log.info("요청 uri : " + request.getRequestURI());
             log.error("토큰이 없음");
 
             // 상태 코드 및 에러 메시지 세팅 (400)
             statusCode = StatusCode.BAD_REQUEST;
-            exceptionMessage = "토큰이 존재하지 않습니다.";
+            exceptionMessage = ResponseMessages.NOT_FOUND_TOKEN.get();
         } catch (MalformedJwtException e) {
             log.error("토큰의 값이 유효하지 않음");
 
             // 상태 코드 및 에러 메시지 세팅 (400)
             statusCode = StatusCode.BAD_REQUEST;
-            exceptionMessage = "토큰의 값이 유효하지 않습니다.";
+            exceptionMessage = ResponseMessages.INVALID_TOKEN_VALUE.get();
         } catch (io.jsonwebtoken.SignatureException e) {
             log.error("토큰의 서명이 올바르지 않음");
 
             // 상태 코드 및 에러 메시지 세팅 (401)
             statusCode = StatusCode.UNAUTHORIZED;
-            exceptionMessage = "토큰의 서명이 올바르지 않습니다.";
+            exceptionMessage = ResponseMessages.INVALID_TOKEN_SIGNATURE.get();
         } catch (UsernameNotFoundException e) {
             log.error("해당 유저 없음");
 

--- a/server/src/main/java/com/codecozy/server/service/AppleTokenService.java
+++ b/server/src/main/java/com/codecozy/server/service/AppleTokenService.java
@@ -13,7 +13,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
-import java.util.Map;
 
 @Service
 public class AppleTokenService {

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -52,10 +52,10 @@ public class BookService {
     private final ConverterService converterService;
 
     // 독서상태 값 모음
-    private final int UNREGISTERED = -1;    // 미등록
-    private final int WANT_TO_READ = 0;     // 읽고 싶은
-    private final int READING = 1;          // 읽는 중
-    private final int FINISH_READ = 2;      // 다 읽음
+    private static final int UNREGISTERED = -1;    // 미등록
+    private static final int WANT_TO_READ = 0;     // 읽고 싶은
+    private static final int READING = 1;          // 읽는 중
+    private static final int FINISH_READ = 2;      // 다 읽음
 
     // 사용자가 독서노트 추가 시 실행 (책 등록, 위치 등록, 독서노트 등록, 최근 검색 위치 등록)
     public ResponseEntity<DefaultResponse> createBook(Long memberId, String isbn, ReadingBookCreateRequest request) {

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.service;
 
+import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.context.StatusCode;
 import com.codecozy.server.dto.request.*;
 import com.codecozy.server.dto.response.*;
@@ -71,7 +72,7 @@ public class BookService {
         // memberId와 isbn을 이용해 사용자별 리뷰 등록 책이 중복되었는지 검사
         BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
         if (bookRecord != null && bookRecord.getBookType() != UNREGISTERED) { // -1: reading_status가 '읽고싶은'(0)인 경우
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "이미 등록한 독서 노트입니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_BOOK_RECORD.get()),
                     HttpStatus.CONFLICT);
         }
 
@@ -114,7 +115,7 @@ public class BookService {
         bookRecordDateRepository.save(BookRecordDate.create(bookRecord));
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -131,7 +132,7 @@ public class BookService {
         bookRecordRepository.delete(bookRecord);
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -240,7 +241,7 @@ public class BookService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", new GetReadingNoteResponse(
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), new GetReadingNoteResponse(
                         cover,
                         title,
                         author,
@@ -290,7 +291,7 @@ public class BookService {
             // 만일 uuid 값이 없다면
             if (request.uuid() == null) {
                 return new ResponseEntity<>(
-                        DefaultResponse.from(StatusCode.BAD_REQUEST, "uuid 값이 없습니다."),
+                        DefaultResponse.from(StatusCode.BAD_REQUEST, ResponseMessages.MISSING_UUID.get()),
                         HttpStatus.BAD_REQUEST);
             }
             bookmarkRepository.save(Bookmark.create(
@@ -316,7 +317,7 @@ public class BookService {
         bookRecordRepository.save(bookRecord);
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -334,7 +335,7 @@ public class BookService {
         bookRecordRepository.save(bookRecord);
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -352,7 +353,7 @@ public class BookService {
         bookRecordRepository.save(bookRecord);
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -388,7 +389,7 @@ public class BookService {
                 response.totalPage(), response.description(), commentCount, selectedReviewList, commentList);
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", response),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), response),
                 HttpStatus.OK);
     }
 
@@ -408,7 +409,8 @@ public class BookService {
             List<BookReview> bookReviews = bookReviewRepository.findAllByBookRecordBook(book);
 
             if (bookReviews.size() <= 0) {
-                return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "등록된 한줄평이 없습니다."),
+                return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND,
+                        ResponseMessages.NOT_FOUND_REGISTERED_COMMENT.get()),
                         HttpStatus.NOT_FOUND);
             }
 
@@ -476,7 +478,8 @@ public class BookService {
             List<BookReview> bookReviews = bookReviewRepository.findAllByBookRecordBookOrderByReviewDateDesc(book);
 
             if (bookReviews.size() <= 0) {
-                return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "등록된 한줄평이 없습니다."),
+                return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND,
+                        ResponseMessages.NOT_FOUND_REGISTERED_COMMENT.get()),
                         HttpStatus.NOT_FOUND);
             }
 
@@ -516,7 +519,7 @@ public class BookService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", response),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), response),
                 HttpStatus.OK);
     }
 
@@ -536,7 +539,7 @@ public class BookService {
         BookReview bookReview = bookReviewRepository.findByBookRecord(bookRecord);
 
         if (bookReview == null) {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 한줄평이 없습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_COMMENT.get()),
                     HttpStatus.NOT_FOUND);
         }
 
@@ -566,12 +569,12 @@ public class BookService {
         }
         // 이미 신고했던 경우
         else {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "이미 신고한 리뷰입니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_REPORT.get()),
                     HttpStatus.CONFLICT);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -591,14 +594,14 @@ public class BookService {
         BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
         if (bookRecord != null) {
             return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.CONFLICT, "독서 노트에 등록한 도서는 읽고 싶은 도서로 등록할 수 없습니다."),
+                    DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CANNOT_REGISTER_BOOK_AS_WANT_TO_READ.get()),
                     HttpStatus.CONFLICT);
         }
         // 읽고싶은 책 등록 시에는 독서노트 생성 전이므로 member, book, reading_status 외에는 임시 데이터로 book_record 레코드 생성 후 저장
         bookRecordRepository.save(BookRecord.create(member, book));
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -619,7 +622,7 @@ public class BookService {
         BookReview bookReview = bookReviewRepository.findByBookRecord(bookRecord);
 
         if (bookReview == null) {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 한줄평이 없습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_COMMENT.get()),
                     HttpStatus.NOT_FOUND);
         }
 
@@ -650,7 +653,7 @@ public class BookService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -690,20 +693,22 @@ public class BookService {
                     bookReviewReviewerRepository.save(bookReviewReviewer);
                     bookReviewReactionRepository.save(bookReviewReaction);
                 } else {
-                    return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 한줄평에 남긴 반응이 없습니다."),
+                    return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND,
+                            ResponseMessages.NOT_FOUND_COMMENT_REACTION.get()),
                             HttpStatus.NOT_FOUND);
                 }
             } else {
-                return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 한줄평에 남긴 반응이 없습니다."),
+                return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND,
+                        ResponseMessages.NOT_FOUND_COMMENT_REACTION.get()),
                         HttpStatus.NOT_FOUND);
             }
         } else {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 한줄평이 없습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_COMMENT.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -751,20 +756,22 @@ public class BookService {
                         bookReviewReviewerRepository.delete(bookReviewReviewer);
                     }
                 } else {
-                    return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 한줄평에 남긴 반응이 없습니다."),
+                    return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND,
+                            ResponseMessages.NOT_FOUND_COMMENT_REACTION.get()),
                             HttpStatus.NOT_FOUND);
                 }
             } else {
-                return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 한줄평에 남긴 반응이 없습니다."),
+                return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND,
+                        ResponseMessages.NOT_FOUND_COMMENT_REACTION.get()),
                         HttpStatus.NOT_FOUND);
             }
         } else {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 한줄평이 없습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_COMMENT.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -788,7 +795,7 @@ public class BookService {
             // 이미 등록한 선택 리뷰면 CONFLICT 응답
             SelectReview selectReview = selectReviewRepository.findByBookRecord(bookRecord);
             if (selectReview != null) {
-                return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "이미 등록한 리뷰입니다."),
+                return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_SELECT_REVIEW.get()),
                         HttpStatus.CONFLICT);
             }
 
@@ -806,7 +813,7 @@ public class BookService {
             // 이미 등록한 한줄평이면 CONFLICT 응답
             BookReview bookReview = bookReviewRepository.findByBookRecord(bookRecord);
             if (bookReview != null) {
-                return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "이미 등록한 한줄평입니다."),
+                return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_COMMENT.get()),
                         HttpStatus.CONFLICT);
             }
 
@@ -837,7 +844,7 @@ public class BookService {
         bookRecordDateRepository.save(bookRecordDate);
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -851,7 +858,7 @@ public class BookService {
         BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
 
         if (bookRecord == null) { // 독서 노트가 없으면 충돌 메세지
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "독서 노트가 없습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_BOOK_RECORD.get()),
                     HttpStatus.NOT_FOUND);
         }
 
@@ -930,7 +937,7 @@ public class BookService {
         bookRecordDateRepository.save(bookRecordDate);
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -950,7 +957,7 @@ public class BookService {
             bookRecord.setKeyWord(null);
             bookRecordRepository.save(bookRecord);
         } else {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 독서노트가 없습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_BOOK_RECORD.get()),
                     HttpStatus.NOT_FOUND);
         }
 
@@ -980,7 +987,7 @@ public class BookService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1013,12 +1020,12 @@ public class BookService {
             // 한줄평 지우기
             bookReviewRepository.delete(bookReview);
         } else {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 한줄평이 없습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_COMMENT.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1038,12 +1045,12 @@ public class BookService {
             bookRecord.setStartDate(converterService.stringToDate(startDate));
             bookRecordRepository.save(bookRecord);
         } else {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 독서노트가 없습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_BOOK_RECORD.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1063,12 +1070,12 @@ public class BookService {
             bookRecord.setRecentDate(converterService.stringToDate(recentDate));
             bookRecordRepository.save(bookRecord);
         } else {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 독서노트가 없습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_BOOK_RECORD.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1096,7 +1103,7 @@ public class BookService {
         if (bookRecord != null) {
             // 대표 위치가 이미 있으면 CONFLICT 응답
             if (bookRecord.getLocationInfo() != null) {
-                return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "대표 위치가 이미 있습니다."),
+                return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_MAIN_LOCATION.get()),
                         HttpStatus.CONFLICT);
             } else { // 대표 위치가 없으면 대표위치 등록
                 bookRecord.setLocationInfo(locationInfo);
@@ -1112,7 +1119,7 @@ public class BookService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1156,7 +1163,7 @@ public class BookService {
             }
         } else {
             return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, "해당 독서 노트가 없습니다."),
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_BOOK_RECORD.get()),
                     HttpStatus.NOT_FOUND);
         }
 
@@ -1169,7 +1176,7 @@ public class BookService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1190,7 +1197,7 @@ public class BookService {
 
             // 삭제하려는 위치 객체가 없으면
             if (preLocation == null) {
-                return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 독서노트의 대표 위치가 없습니다."),
+                return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_MAIN_LOCATION.get()),
                         HttpStatus.NOT_FOUND);
             }
 
@@ -1207,12 +1214,12 @@ public class BookService {
                 locationInfoRepository.delete(preLocation);
             }
         } else {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 독서노트가 없습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_BOOK_RECORD.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1234,7 +1241,7 @@ public class BookService {
 
         // 중복된 인물이면 (이름이 중복됐으면)
         if (personalDictionary != null) {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "이미 등록한 인물입니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_CHARACTER.get()),
                     HttpStatus.CONFLICT);
         } else {
             // 인물사전에 등록
@@ -1244,7 +1251,7 @@ public class BookService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1271,12 +1278,12 @@ public class BookService {
                     Integer.parseInt(request.emoji()), request.preview(), request.description());
             personalDictionaryRepository.save(personalDictionary);
         } else {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "등록하지 않은 인물입니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.UNREGISTERED_CHARACTER.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1300,12 +1307,12 @@ public class BookService {
             personalDictionaryRepository.delete(personalDictionary);
         } else {
             return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, "해당 인물이 없습니다."),
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_CHARACTER.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
 
     }
@@ -1337,7 +1344,7 @@ public class BookService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", personalDictionaryList),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), personalDictionaryList),
                 HttpStatus.OK);
     }
 
@@ -1354,7 +1361,7 @@ public class BookService {
 
         Memo memo = memoRepository.findByBookRecordAndUuid(bookRecord, request.uuid());
         if (memo != null) {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "이미 등록한 메모입니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_MEMO.get()),
                     HttpStatus.CONFLICT);
         }
 
@@ -1377,7 +1384,7 @@ public class BookService {
         bookRecordDateRepository.save(bookRecordDate);
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1403,7 +1410,7 @@ public class BookService {
             memo = Memo.create(bookRecord, request.uuid(), request.markPage(), date, request.memoText());
             memoRepository.save(memo);
         } else {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "등록하지 않은 메모입니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.UNREGISTERED_MEMO.get()),
                     HttpStatus.NOT_FOUND);
         }
 
@@ -1413,7 +1420,7 @@ public class BookService {
         bookRecordDateRepository.save(bookRecordDate);
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1435,12 +1442,12 @@ public class BookService {
             memoRepository.delete(memo);
         } else {
             return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, "해당 메모가 없습니다."),
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_MEMO.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1476,7 +1483,7 @@ public class BookService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", memoList),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), memoList),
                 HttpStatus.OK);
     }
 
@@ -1493,7 +1500,7 @@ public class BookService {
 
         Bookmark bookmark = bookmarkRepository.findByBookRecordAndUuid(bookRecord, request.uuid());
         if (bookmark != null) {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "이미 등록한 책갈피입니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_BOOKMARK.get()),
                     HttpStatus.CONFLICT);
         }
 
@@ -1560,7 +1567,7 @@ public class BookService {
         bookRecordDateRepository.save(bookRecordDate);
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1633,12 +1640,12 @@ public class BookService {
             bookRecordDate.setLastDate(LocalDateTime.now());
             bookRecordDateRepository.save(bookRecordDate);
         } else {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "등록하지 않은 책갈피입니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.UNREGISTERED_BOOKMARK.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1677,12 +1684,12 @@ public class BookService {
             bookmarkRepository.delete(bookmark);
         } else {
             return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, "해당 책갈피가 없습니다."),
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_BOOKMARK.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1727,7 +1734,7 @@ public class BookService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", bookmarkList),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), bookmarkList),
                 HttpStatus.OK);
     }
 
@@ -1750,14 +1757,14 @@ public class BookService {
 
         if (locationInfo.isEmpty()) {
             return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, "조회할 위치가 없습니다."),
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_LOCATION.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         AllLocationResponse allLocationResponse = new AllLocationResponse(locationInfo, (isBookRecordEnd.getValue() && isBookmarkEnd.getValue()));
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", allLocationResponse),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), allLocationResponse),
                 HttpStatus.OK);
     }
 
@@ -1781,12 +1788,12 @@ public class BookService {
 
         if (location.isEmpty()) {
             return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, "조회할 위치가 없습니다."),
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_LOCATION.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", location),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), location),
                 HttpStatus.OK);
     }
 
@@ -1814,17 +1821,17 @@ public class BookService {
                 }
             } else {
                 return new ResponseEntity<>(
-                        DefaultResponse.from(StatusCode.NOT_FOUND, "최근 등록된 위치가 아닙니다."),
+                        DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_LATEST_LOCATION.get()),
                         HttpStatus.NOT_FOUND);
             }
         } else {
             return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, "등록되지 않은 위치입니다."),
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.UNREGISTERED_LOCATION.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -1852,12 +1859,12 @@ public class BookService {
 
         if (allMarkers.isEmpty()) { // 조회할 마크가 하나도 없는 경우
             return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, "조회할 마크가 없습니다."),
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_MARKER.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", allMarkers),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), allMarkers),
                 HttpStatus.OK);
     }
 
@@ -1887,12 +1894,13 @@ public class BookService {
 
         if (locationInfoList.isEmpty()) { // 세부 조회할 마크가 하나도 없는 경우
             return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, "세부 조회할 마크가 없습니다."),
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_MARKER_TO_DETAIL.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", new AllLocationResponse(locationInfoList, (isBookRecordEnd.getValue() && isBookmarkEnd.getValue()))),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(),
+                        new AllLocationResponse(locationInfoList, (isBookRecordEnd.getValue() && isBookmarkEnd.getValue()))),
                 HttpStatus.OK);
     }
 

--- a/server/src/main/java/com/codecozy/server/service/BookshelfService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookshelfService.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.service;
 
+import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.context.StatusCode;
 import com.codecozy.server.dto.response.DefaultResponse;
 import com.codecozy.server.dto.response.AllBookshelfResponse;
@@ -179,7 +180,8 @@ public class BookshelfService {
             }
         }
 
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "성공", bookshelfResponseList), HttpStatus.OK);
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), bookshelfResponseList),
+                HttpStatus.OK);
     }
 
     // 책장 리스트용 조회
@@ -275,7 +277,7 @@ public class BookshelfService {
             }
         }
 
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "성공", detailBookshelfResponseList),
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), detailBookshelfResponseList),
                 HttpStatus.OK);
     }
 }

--- a/server/src/main/java/com/codecozy/server/service/CustomUserDetailsService.java
+++ b/server/src/main/java/com/codecozy/server/service/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.service;
 
+import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.dto.CustomUserDetails;
 import com.codecozy.server.entity.Member;
 import com.codecozy.server.repository.MemberRepository;
@@ -20,7 +21,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         Member member = memberRepository.findByMemberId(memberId);
 
         if (member == null) {
-            throw new UsernameNotFoundException("(토큰 오류) 해당 유저가 존재하지 않습니다.");
+            throw new UsernameNotFoundException(ResponseMessages.INVALID_USER.get());
         }
 
         return new CustomUserDetails(username);

--- a/server/src/main/java/com/codecozy/server/service/HomeService.java
+++ b/server/src/main/java/com/codecozy/server/service/HomeService.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.service;
 
+import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.context.StatusCode;
 import com.codecozy.server.dto.response.DefaultResponse;
 import com.codecozy.server.dto.response.FinishReadResponse;
@@ -231,7 +232,7 @@ public class HomeService {
 
         // 응답 보내기
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공",
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(),
                         new GetMainResponse(booksList, wantToReadCount,
                                 readingCount)),
                 HttpStatus.OK);
@@ -323,7 +324,7 @@ public class HomeService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", response),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), response),
                 HttpStatus.OK);
     }
 
@@ -353,7 +354,7 @@ public class HomeService {
         }
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", wantToReadBooks),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), wantToReadBooks),
                 HttpStatus.OK);
     }
 
@@ -415,7 +416,7 @@ public class HomeService {
 
         // 응답 보내기
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", readingBooks),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), readingBooks),
                 HttpStatus.OK);
     }
 
@@ -452,7 +453,7 @@ public class HomeService {
 
         // 응답 보내기
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공", finishReadBooks),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), finishReadBooks),
                 HttpStatus.OK);
     }
 
@@ -471,7 +472,7 @@ public class HomeService {
         bookRecordRepository.save(bookRecord);
 
         return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, "성공"),
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 

--- a/server/src/main/java/com/codecozy/server/service/HomeService.java
+++ b/server/src/main/java/com/codecozy/server/service/HomeService.java
@@ -58,10 +58,10 @@ public class HomeService {
     private final SelectReviewRepository selectReviewRepository;
 
     // 독서 상태 상수 값
-    private final int UNREGISTERED = -1;    // 미등록
-    private final int WANT_TO_READ = 0;     // 읽고 싶은
-    private final int READING = 1;          // 읽는 중
-    private final int FINISH_READ = 2;      // 다 읽음
+    private static final int UNREGISTERED = -1;    // 미등록
+    private static final int WANT_TO_READ = 0;     // 읽고 싶은
+    private static final int READING = 1;          // 읽는 중
+    private static final int FINISH_READ = 2;      // 다 읽음
 
     // 검색 시 불러온 응답 JSON 데이터를 원하는 값만 파싱하는 메소드
     private SearchResponse parsingData(String jsonStr) {

--- a/server/src/main/java/com/codecozy/server/service/MemberService.java
+++ b/server/src/main/java/com/codecozy/server/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.service;
 
+import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.context.StatusCode;
 import com.codecozy.server.dto.request.SignInAppleRequest;
 import com.codecozy.server.dto.request.SignUpAppleRequest;
@@ -20,7 +21,6 @@ import com.codecozy.server.security.TokenProvider;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.NonUniqueResultException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -41,10 +41,10 @@ public class MemberService {
         Member member = memberRepository.findByNickname(nickname);
 
         if (member != null) {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "사용 불가능한 닉네임입니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_NICKNAME.get()),
                     HttpStatus.CONFLICT);
         }
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "사용 가능한 닉네임입니다."),
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.OK_NICKNAME.get()),
                 HttpStatus.OK);
     }
 
@@ -63,7 +63,8 @@ public class MemberService {
         Long memberId = member.getMemberId();
         String accessToken = tokenProvider.createAccessToken(memberId);
 
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "성공", new SignUpKakaoResponse(accessToken)),
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(),
+                new SignUpKakaoResponse(accessToken)),
                 HttpStatus.OK);
     }
 
@@ -75,7 +76,7 @@ public class MemberService {
         // 기가입 유저 X
         if (memberKakao == null) {
             // 실패 응답
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 사용자가 존재하지 않습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_USER.get()),
                     HttpStatus.NOT_FOUND);
        }
         // 기가입 유저 O
@@ -83,7 +84,8 @@ public class MemberService {
         Long memberId = memberKakao.getMemberId();
         String accessToken = tokenProvider.createAccessToken(memberId);
 
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "성공", new SignUpKakaoResponse(accessToken)),
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(),
+                new SignUpKakaoResponse(accessToken)),
                 HttpStatus.OK);
     }
 
@@ -91,14 +93,14 @@ public class MemberService {
     public ResponseEntity<DefaultResponse> signUpApple(SignUpAppleRequest request) throws Exception {
         // idToken 유효성 검증(JWK 확인, Claim 확인)
         if (!appleTokenService.isValid(request.idToken())) {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "ID 토큰이 유효하지 않습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.INVALID_ID_TOKEN.get()),
                     HttpStatus.NOT_FOUND);
         }
 
         // 이미 가입한 유저인지 확인
         MemberApple signedUpUser = memberAppleRepository.findByUserIdentifier(request.userIdentifier());
         if (signedUpUser != null) {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "이미 가입한 회원입니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_USER.get()),
                     HttpStatus.CONFLICT);
         }
 
@@ -115,7 +117,8 @@ public class MemberService {
         Long memberId = member.getMemberId();
         String accessToken = tokenProvider.createAccessToken(memberId);
 
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "성공", new SignUpKakaoResponse(accessToken)),
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(),
+                new SignUpKakaoResponse(accessToken)),
                 HttpStatus.OK);
     }
 
@@ -123,7 +126,7 @@ public class MemberService {
     public ResponseEntity<DefaultResponse> signInApple(SignInAppleRequest request) {
         // idToken 유효성 검증
         if (!appleTokenService.isValid(request.idToken())) {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "ID 토큰이 유효하지 않습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.INVALID_ID_TOKEN.get()),
                     HttpStatus.NOT_FOUND);
         }
 
@@ -131,7 +134,7 @@ public class MemberService {
         MemberApple memberApple = memberAppleRepository.findByUserIdentifier(request.userIdentifier());
 
         if (memberApple == null) {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, "해당 사용자가 존재하지 않습니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_USER.get()),
                     HttpStatus.NOT_FOUND);
         }
 
@@ -139,7 +142,8 @@ public class MemberService {
         Long memberId = memberApple.getMember().getMemberId();
         String accessToken = tokenProvider.createAccessToken(memberId);
 
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "성공", new SignUpKakaoResponse(accessToken)),
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(),
+                new SignUpKakaoResponse(accessToken)),
                 HttpStatus.OK);
     }
 
@@ -150,7 +154,7 @@ public class MemberService {
 
         // 해당 닉네임이 이미 있다면
         if (memberRepository.findByNickname(nickname) != null) {
-            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, "사용 불가능한 닉네임입니다."),
+            return new ResponseEntity<>(DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_NICKNAME.get()),
                     HttpStatus.CONFLICT);
         }
 
@@ -158,7 +162,7 @@ public class MemberService {
         member.modifyNickname(nickname);
         memberRepository.save(member);
 
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "성공"),
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -170,7 +174,7 @@ public class MemberService {
         member.modifyProfileImg(profileImgCode);
         memberRepository.save(member);
 
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "성공"),
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -179,7 +183,7 @@ public class MemberService {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
         memberRepository.deleteById(memberId);
 
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "성공"),
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get()),
                 HttpStatus.OK);
     }
 
@@ -194,7 +198,7 @@ public class MemberService {
         int badgeCount = badgeList.size();
         String profileImgCode = member.getProfile();
 
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "성공",
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(),
                 new ProfileResponse(nickname, badgeCount, profileImgCode)),
                 HttpStatus.OK);
     }
@@ -244,7 +248,7 @@ public class MemberService {
             }
         }
 
-        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, "성공", badgeResponseList),
+        return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), badgeResponseList),
                 HttpStatus.OK);
     }
 }

--- a/server/src/test/java/com/codecozy/server/service/BookServiceTest.java
+++ b/server/src/test/java/com/codecozy/server/service/BookServiceTest.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.service;
 
+import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.dto.request.BookmarkRequest;
 import com.codecozy.server.dto.request.MemoRequest;
 import com.codecozy.server.dto.request.ModifyReadingStatusRequest;
@@ -167,7 +168,7 @@ class BookServiceTest {
             ResponseEntity<DefaultResponse> response = bookService.getReadingNote(member.getMemberId(), book.getIsbn());
 
             // then
-            assertThat(response.getBody().getMessage()).isEqualTo("성공");
+            assertThat(response.getBody().getMessage()).isEqualTo(ResponseMessages.SUCCESS.get());
 
             GetReadingNoteResponse dto = getJsonData(response, GetReadingNoteResponse.class);
             assertThat(dto.firstReviewDate()).isEqualTo("2025.01.16");
@@ -180,7 +181,7 @@ class BookServiceTest {
             ResponseEntity<DefaultResponse> response = bookService.getReadingNote(member.getMemberId(), book.getIsbn());
 
             // then
-            assertThat(response.getBody().getMessage()).isEqualTo("성공");
+            assertThat(response.getBody().getMessage()).isEqualTo(ResponseMessages.SUCCESS.get());
 
             GetReadingNoteResponse dto = getJsonData(response, GetReadingNoteResponse.class);
             assertThat(dto.firstReviewDate()).isNull();
@@ -213,7 +214,7 @@ class BookServiceTest {
             // then
             // http 응답 확인
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getMessage()).isEqualTo("성공");
+            assertThat(response.getBody().getMessage()).isEqualTo(ResponseMessages.SUCCESS.get());
 
             // 데이터 확인
             BookRecord found = getCapturedBookRecord();
@@ -235,7 +236,7 @@ class BookServiceTest {
             // then
             // http 응답 확인
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-            assertThat(response.getBody().getMessage()).isEqualTo("uuid 값이 없습니다.");
+            assertThat(response.getBody().getMessage()).isEqualTo(ResponseMessages.MISSING_UUID.get());
             // save 메소드가 호출되지 않았음을 검증
             verify(bookRecordRepository, never()).save(any(BookRecord.class));
         }
@@ -254,7 +255,7 @@ class BookServiceTest {
             // then
             // http 응답 확인
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getMessage()).isEqualTo("성공");
+            assertThat(response.getBody().getMessage()).isEqualTo(ResponseMessages.SUCCESS.get());
 
             // 독서노트 데이터 확인
             BookRecord found = getCapturedBookRecord();
@@ -279,7 +280,7 @@ class BookServiceTest {
                 request);
 
         // then
-        assertThat(response.getBody().getMessage()).isEqualTo("성공");
+        assertThat(response.getBody().getMessage()).isEqualTo(ResponseMessages.SUCCESS.get());
         verifyCapturedBookmark("3b7d", 110, LocalDate.of(2024, 12, 17));
     }
 
@@ -297,7 +298,7 @@ class BookServiceTest {
         ResponseEntity<DefaultResponse> response = bookService.addMemo(member.getMemberId(), book.getIsbn(), request);
 
         // then
-        assertThat(response.getBody().getMessage()).isEqualTo("성공");
+        assertThat(response.getBody().getMessage()).isEqualTo(ResponseMessages.SUCCESS.get());
         verifyCapturedMemo("6a1b", 50, "라이언 첫 등장", LocalDate.of(2024, 12, 29));
     }
 
@@ -316,7 +317,7 @@ class BookServiceTest {
                 request);
 
         // then
-        assertThat(response.getBody().getMessage()).isEqualTo("성공");
+        assertThat(response.getBody().getMessage()).isEqualTo(ResponseMessages.SUCCESS.get());
         verifyCapturedMemo("5c8i", 60, "라이언 두 마리 등장", LocalDate.of(2025, 1, 1));
     }
 }

--- a/server/src/test/java/com/codecozy/server/service/BookServiceTest.java
+++ b/server/src/test/java/com/codecozy/server/service/BookServiceTest.java
@@ -192,10 +192,10 @@ class BookServiceTest {
     @DisplayName("독서상태 변경 테스트")
     class ModifyReadingStatus {
         // 독서상태 값 모음
-//        final int UNREGISTERED = -1;    // 미등록
-//        final int WANT_TO_READ = 0;     // 읽고 싶은
-        final int READING = 1;          // 읽는 중
-        final int FINISH_READ = 2;      // 다 읽음
+//        static final int UNREGISTERED = -1;    // 미등록
+//        static final int WANT_TO_READ = 0;     // 읽고 싶은
+        static final int READING = 1;          // 읽는 중
+        static final int FINISH_READ = 2;      // 다 읽음
 
         @Test
         @DisplayName("succeed: 읽는중 -> 다읽음 전환하기")
@@ -218,6 +218,7 @@ class BookServiceTest {
 
             // 데이터 확인
             BookRecord found = getCapturedBookRecord();
+            assertThat(found.getReadingStatus()).isEqualTo(FINISH_READ);
             assertThat(found.getRecentDate()).isEqualTo(nowDate);
             verifyCapturedBookmark("TEST-UUID", book.getTotalPage(), nowDate);
         }


### PR DESCRIPTION
## 목적🎯
- 독서상태 변경 API 내 로직 추가
- 응답에 보내는 메시지 하드코딩 제거
  - 응답 메시지에 일관성을 주고, 관리를 용이하게 하기 위해 메시지들을 한 곳에 모았습니다.

## 변경사항🛠️
- **독서상태 변경 API 로직 추가**
  - 읽는중->다읽음 전환 시
    - 마지막 읽은 날짜 수정
    - 독서 진행률 100%로 수정
    - 100% 책갈피 하나 추가
  - 다읽음->읽는중 전환 시
    - 독서 진행률 0%로 수정
- **메시지 Enum 클래스 적용**
  - 수정사항을 적용한 파일 목록
    - `CustomUserDetailsService.java`
    - `JwtAuthenticateFilter.java`
    - `MemberService.java`
    - `HomeService.java`
    - `BookService.java`
    - `BookshelfService.java`

## 수행한 테스트✏️
- 독서상태 변경 API 테스트
  - 읽는중->다읽음 전환하기 (모든 필요 데이터가 다 있는 경우)
  - 읽는중->다읽음 전환을 시도하나, uuid 값 없이 요청이 왔을 경우
  - 다읽음->읽는중 전환하기