### PR TITLE
API URL 변경 작업

### DIFF
--- a/server/src/main/java/com/codecozy/server/controller/BookController.java
+++ b/server/src/main/java/com/codecozy/server/controller/BookController.java
@@ -14,6 +14,7 @@ import java.util.Map;
 @RequestMapping("/book")
 @RequiredArgsConstructor
 public class BookController {
+    
     private final TokenProvider tokenProvider;
     private final BookService bookService;
 
@@ -78,18 +79,6 @@ public class BookController {
         return bookService.searchBookDetail(memberId, isbn);
     }
 
-    // 한줄평 추가 조회 API
-    @GetMapping("/comment/more")
-    public ResponseEntity commentDetail(@RequestHeader("xAuthToken") String token,
-                                        @RequestParam("isbn") String isbn,
-                                        @RequestParam("orderNumber") Integer orderNumber,
-                                        @RequestParam("orderType") Boolean orderType) {
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
-        CommentDetailRequest request = new CommentDetailRequest(orderNumber, orderType);
-
-        return bookService.commentDetail(memberId, isbn, request);
-    }
-
     // 리뷰 작성 API
     @PostMapping("/review/{isbn}")
     public ResponseEntity createReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
@@ -114,6 +103,18 @@ public class BookController {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
         return bookService.deleteReview(memberId, isbn);
+    }
+
+    // 한줄평 추가 조회 API
+    @GetMapping("/comment/more")
+    public ResponseEntity commentDetail(@RequestHeader("xAuthToken") String token,
+            @RequestParam("isbn") String isbn,
+            @RequestParam("orderNumber") Integer orderNumber,
+            @RequestParam("orderType") Boolean orderType) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+        CommentDetailRequest request = new CommentDetailRequest(orderNumber, orderType);
+
+        return bookService.commentDetail(memberId, isbn, request);
     }
 
     // 한줄평 삭제 API
@@ -323,15 +324,6 @@ public class BookController {
         return bookService.getBookmark(memberId, isbn);
     }
 
-    // 전체 위치 조회 API
-    @GetMapping("/map/location/{orderNumber}")
-    public ResponseEntity getAllLocation(@RequestHeader("xAuthToken") String token,
-                                         @PathVariable("orderNumber") Integer orderNumber) {
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
-
-        return bookService.getAllLocation(memberId, orderNumber);
-    }
-
     // 최근 등록 위치 조회 API
     @GetMapping("/recent-location")
     public ResponseEntity getRecentLocation(@RequestHeader("xAuthToken") String token) {
@@ -347,24 +339,5 @@ public class BookController {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
         return bookService.deleteRecentLocation(memberId, request);
-    }
-
-    // 지도 마크 조회 API
-    @GetMapping("/map/marker")
-    public ResponseEntity getAllMarker(@RequestHeader("xAuthToken") String token) {
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
-
-        return bookService.getAllMarker(memberId);
-    }
-
-    // 마크 세부 조회 API
-    @GetMapping("/map/marker/detail")
-    public ResponseEntity getMarkDetail(@RequestHeader("xAuthToken") String token,
-                                        @RequestParam("locationId") Long locationId,
-                                        @RequestParam("orderNumber") Integer orderNumber) {
-        Long memberId = tokenProvider.getMemberIdFromToken(token);
-        MarkDetailRequest request = new MarkDetailRequest(locationId, orderNumber);
-
-        return bookService.getMarkDetail(memberId, request);
     }
 }

--- a/server/src/main/java/com/codecozy/server/controller/BookController.java
+++ b/server/src/main/java/com/codecozy/server/controller/BookController.java
@@ -14,7 +14,7 @@ import java.util.Map;
 @RequestMapping("/book")
 @RequiredArgsConstructor
 public class BookController {
-    
+
     private final TokenProvider tokenProvider;
     private final BookService bookService;
 
@@ -44,7 +44,7 @@ public class BookController {
     }
 
     // 독서상태 변경 API
-    @PatchMapping("/reading-status/{isbn}")
+    @PatchMapping("/{isbn}/reading-status")
     public ResponseEntity modifyReadingStatus(@RequestHeader("xAuthToken") String token,
                                               @PathVariable("isbn") String isbn,
                                               @RequestBody ModifyReadingStatusRequest request) {
@@ -54,7 +54,7 @@ public class BookController {
     }
 
     // 소장여부 변경 API
-    @PatchMapping("/is-mine/{isbn}")
+    @PatchMapping("/{isbn}/is-mine")
     public ResponseEntity modifyIsMine(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                        @RequestBody Map<String, Boolean> isMineMap) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -63,7 +63,7 @@ public class BookController {
     }
 
     // 책 유형 변경 API
-    @PatchMapping("/book-type/{isbn}")
+    @PatchMapping("/{isbn}/book-type")
     public ResponseEntity modifyBookType(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                          @RequestBody Map<String, Integer> bookTypeMap) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -72,7 +72,7 @@ public class BookController {
     }
 
     // 도서정보 초기 조회 API
-    @GetMapping("/info/{isbn}")
+    @GetMapping("/{isbn}/info")
     public ResponseEntity searchBookDetail(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) throws IOException {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -80,7 +80,7 @@ public class BookController {
     }
 
     // 리뷰 작성 API
-    @PostMapping("/review/{isbn}")
+    @PostMapping("/{isbn}/review")
     public ResponseEntity createReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                        @RequestBody ReviewCreateRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -89,7 +89,7 @@ public class BookController {
     }
 
     // 리뷰 전체 수정 API
-    @PatchMapping("/review/{isbn}")
+    @PatchMapping("/{isbn}/review")
     public ResponseEntity modifyReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                        @RequestBody ReviewCreateRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -98,7 +98,7 @@ public class BookController {
     }
 
     // 리뷰 전체 삭제 API
-    @DeleteMapping("/review/{isbn}")
+    @DeleteMapping("/{isbn}/review")
     public ResponseEntity deleteReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -106,9 +106,9 @@ public class BookController {
     }
 
     // 한줄평 추가 조회 API
-    @GetMapping("/comment/more")
+    @GetMapping("/{isbn}/comment/more")
     public ResponseEntity commentDetail(@RequestHeader("xAuthToken") String token,
-            @RequestParam("isbn") String isbn,
+            @PathVariable("isbn") String isbn,
             @RequestParam("orderNumber") Integer orderNumber,
             @RequestParam("orderType") Boolean orderType) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -118,7 +118,7 @@ public class BookController {
     }
 
     // 한줄평 삭제 API
-    @DeleteMapping("/comment/{isbn}")
+    @DeleteMapping("/{isbn}/comment")
     public ResponseEntity deleteComment(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -126,7 +126,7 @@ public class BookController {
     }
 
     // 한줄평 반응 추가 API
-    @PostMapping("/comment/reaction/{isbn}")
+    @PostMapping("/{isbn}/comment/reaction")
     public ResponseEntity reactionComment(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                           @RequestBody CommentReactionRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -135,7 +135,7 @@ public class BookController {
     }
 
     // 한줄평 반응 수정 API
-    @PatchMapping("/comment/reaction/{isbn}")
+    @PatchMapping("/{isbn}/comment/reaction")
     public ResponseEntity modifyReaction(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                          @RequestBody CommentReactionRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -144,7 +144,7 @@ public class BookController {
     }
 
     // 한줄평 반응 삭제 API
-    @DeleteMapping("/comment/reaction/{isbn}")
+    @DeleteMapping("/{isbn}/comment/reaction")
     public ResponseEntity deleteReaction(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                          @RequestBody DeleteReactionRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -153,7 +153,7 @@ public class BookController {
     }
 
     // 신고하기 API
-    @PostMapping("/comment/report/{isbn}")
+    @PostMapping("/{isbn}/comment/report")
     public ResponseEntity reportComment(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                         @RequestBody ReportCommentRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -162,7 +162,7 @@ public class BookController {
     }
 
     // 읽고싶은 책 등록 API
-    @PostMapping("/want-to-read/{isbn}")
+    @PostMapping("/{isbn}/want-to-read")
     public ResponseEntity wantToRead(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                      @RequestBody BookCreateRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -171,7 +171,7 @@ public class BookController {
     }
 
     // 읽기 시작한 날짜 변경 API
-    @PatchMapping("/start-date/{isbn}")
+    @PatchMapping("/{isbn}/start-date")
     public ResponseEntity modifyStartDate(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                           @RequestBody Map<String, String> startDateMap) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -180,7 +180,7 @@ public class BookController {
     }
 
     // 마지막 읽은 날짜 변경 API
-    @PatchMapping("/recent-date/{isbn}")
+    @PatchMapping("/{isbn}/recent-date")
     public ResponseEntity modifyRecentDate(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                            @RequestBody Map<String, String> recentDateMap) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -189,7 +189,7 @@ public class BookController {
     }
 
     // 책별 대표 위치 등록 API
-    @PostMapping("/main-location/{isbn}")
+    @PostMapping("/{isbn}/main-location")
     public ResponseEntity addMainLocation(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                           @RequestBody LocationRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -198,7 +198,7 @@ public class BookController {
     }
 
     // 책별 대표 위치 변경 API
-    @PatchMapping("/main-location/{isbn}")
+    @PatchMapping("/{isbn}/main-location")
     public ResponseEntity modifyMainLocation(@RequestHeader("xAuthToken") String token,
                                              @PathVariable("isbn") String isbn, @RequestBody LocationRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -207,7 +207,7 @@ public class BookController {
     }
 
     // 책별 대표 위치 삭제 API
-    @DeleteMapping("/main-location/{isbn}")
+    @DeleteMapping("/{isbn}/main-location")
     public ResponseEntity deleteMainLocation(@RequestHeader("xAuthToken") String token,
                                              @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -216,7 +216,7 @@ public class BookController {
     }
 
     // 인물사전 등록 API
-    @PostMapping("/character-dictionary/{isbn}")
+    @PostMapping("/{isbn}/character-dictionary")
     public ResponseEntity addPersonalDictionary(@RequestHeader("xAuthToken") String token,
                                                 @PathVariable("isbn") String isbn,
                                                 @RequestBody PersonalDictionaryRequest request) {
@@ -226,7 +226,7 @@ public class BookController {
     }
 
     // 인물사전 수정 API
-    @PatchMapping("/character-dictionary/{isbn}")
+    @PatchMapping("/{isbn}/character-dictionary")
     public ResponseEntity modifyPersonalDictionary(@RequestHeader("xAuthToken") String token,
                                                    @PathVariable("isbn") String isbn,
                                                    @RequestBody PersonalDictionaryRequest request) {
@@ -236,7 +236,7 @@ public class BookController {
     }
 
     // 인물사전 삭제 API
-    @DeleteMapping("/character-dictionary/{isbn}")
+    @DeleteMapping("/{isbn}/character-dictionary")
     public ResponseEntity deletePersonalDictionary(@RequestHeader("xAuthToken") String token,
                                                    @PathVariable("isbn") String isbn,
                                                    @RequestBody DeletePersonalDictionaryRequest request) {
@@ -246,7 +246,7 @@ public class BookController {
     }
 
     // 인물사전 전체조회 API
-    @GetMapping("/character-dictionary/{isbn}")
+    @GetMapping("/{isbn}/character-dictionary")
     public ResponseEntity getPersonalDictionary(@RequestHeader("xAuthToken") String token,
                                                 @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -255,7 +255,7 @@ public class BookController {
     }
 
     // 메모 등록 API
-    @PostMapping("/memo/{isbn}")
+    @PostMapping("/{isbn}/memo")
     public ResponseEntity addMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                   @RequestBody MemoRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -264,7 +264,7 @@ public class BookController {
     }
 
     // 메모 수정 API
-    @PatchMapping("/memo/{isbn}")
+    @PatchMapping("/{isbn}/memo")
     public ResponseEntity modifyMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                      @RequestBody MemoRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -273,7 +273,7 @@ public class BookController {
     }
 
     // 메모 삭제 API
-    @DeleteMapping("/memo/{isbn}")
+    @DeleteMapping("/{isbn}/memo")
     public ResponseEntity deleteMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                      @RequestBody DeleteUuidRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -282,7 +282,7 @@ public class BookController {
     }
 
     // 메모 전체조회 API
-    @GetMapping("/memo/{isbn}")
+    @GetMapping("/{isbn}/memo")
     public ResponseEntity getMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -290,7 +290,7 @@ public class BookController {
     }
 
     // 책갈피 등록 API
-    @PostMapping("/bookmark/{isbn}")
+    @PostMapping("/{isbn}/bookmark")
     public ResponseEntity addBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                       @RequestBody BookmarkRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -299,7 +299,7 @@ public class BookController {
     }
 
     // 책갈피 수정 API
-    @PatchMapping("/bookmark/{isbn}")
+    @PatchMapping("/{isbn}/bookmark")
     public ResponseEntity modifyBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                          @RequestBody BookmarkRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -308,7 +308,7 @@ public class BookController {
     }
 
     // 책갈피 삭제 API
-    @DeleteMapping("/bookmark/{isbn}")
+    @DeleteMapping("/{isbn}/bookmark")
     public ResponseEntity deleteBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                          @RequestBody DeleteUuidRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -317,7 +317,7 @@ public class BookController {
     }
 
     // 책갈피 전체조회 API
-    @GetMapping("/bookmark/{isbn}")
+    @GetMapping("/{isbn}/bookmark")
     public ResponseEntity getBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -333,11 +333,11 @@ public class BookController {
     }
 
     // 최근 등록 위치 삭제 API
-    @DeleteMapping("/recent-location")
+    @DeleteMapping("/recent-location/{id}")
     public ResponseEntity deleteRecentLocation(@RequestHeader("xAuthToken") String token,
-                                               @RequestBody DeleteRecentLocationRequest request) {
+                                               @PathVariable("id") Long locationId) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
-        return bookService.deleteRecentLocation(memberId, request);
+        return bookService.deleteRecentLocation(memberId, locationId);
     }
 }

--- a/server/src/main/java/com/codecozy/server/controller/BookController.java
+++ b/server/src/main/java/com/codecozy/server/controller/BookController.java
@@ -18,7 +18,7 @@ public class BookController {
     private final BookService bookService;
 
     // 책 등록 API
-    @PostMapping("/create/{isbn}")
+    @PostMapping("/{isbn}")
     public ResponseEntity createBook(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                      @RequestBody ReadingBookCreateRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -27,7 +27,7 @@ public class BookController {
     }
 
     // 책 삭제 API
-    @DeleteMapping("/delete/{isbn}")
+    @DeleteMapping("/{isbn}")
     public ResponseEntity deleteBook(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -35,7 +35,7 @@ public class BookController {
     }
 
     // 책별 독서노트 조회 API
-    @GetMapping("/readingNote/{isbn}")
+    @GetMapping("/{isbn}")
     public ResponseEntity getReadingNote(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -43,7 +43,7 @@ public class BookController {
     }
 
     // 독서상태 변경 API
-    @PatchMapping("/readingStatus/{isbn}")
+    @PatchMapping("/reading-status/{isbn}")
     public ResponseEntity modifyReadingStatus(@RequestHeader("xAuthToken") String token,
                                               @PathVariable("isbn") String isbn,
                                               @RequestBody ModifyReadingStatusRequest request) {
@@ -53,7 +53,7 @@ public class BookController {
     }
 
     // 소장여부 변경 API
-    @PatchMapping("/isMine/{isbn}")
+    @PatchMapping("/is-mine/{isbn}")
     public ResponseEntity modifyIsMine(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                        @RequestBody Map<String, Boolean> isMineMap) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -62,7 +62,7 @@ public class BookController {
     }
 
     // 책 유형 변경 API
-    @PatchMapping("/bookType/{isbn}")
+    @PatchMapping("/book-type/{isbn}")
     public ResponseEntity modifyBookType(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                          @RequestBody Map<String, Integer> bookTypeMap) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -71,7 +71,7 @@ public class BookController {
     }
 
     // 도서정보 초기 조회 API
-    @GetMapping("/bookDetail/{isbn}")
+    @GetMapping("/info/{isbn}")
     public ResponseEntity searchBookDetail(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) throws IOException {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -79,7 +79,7 @@ public class BookController {
     }
 
     // 한줄평 추가 조회 API
-    @GetMapping("/commentDetail")
+    @GetMapping("/comment/more")
     public ResponseEntity commentDetail(@RequestHeader("xAuthToken") String token,
                                         @RequestParam("isbn") String isbn,
                                         @RequestParam("orderNumber") Integer orderNumber,
@@ -100,7 +100,7 @@ public class BookController {
     }
 
     // 리뷰 전체 수정 API
-    @PatchMapping("/modifyReview/{isbn}")
+    @PatchMapping("/review/{isbn}")
     public ResponseEntity modifyReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                        @RequestBody ReviewCreateRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -109,7 +109,7 @@ public class BookController {
     }
 
     // 리뷰 전체 삭제 API
-    @DeleteMapping("/deleteReview/{isbn}")
+    @DeleteMapping("/review/{isbn}")
     public ResponseEntity deleteReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -117,7 +117,7 @@ public class BookController {
     }
 
     // 한줄평 삭제 API
-    @DeleteMapping("/deleteComment/{isbn}")
+    @DeleteMapping("/comment/{isbn}")
     public ResponseEntity deleteComment(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -125,7 +125,7 @@ public class BookController {
     }
 
     // 한줄평 반응 추가 API
-    @PostMapping("/reaction/{isbn}")
+    @PostMapping("/comment/reaction/{isbn}")
     public ResponseEntity reactionComment(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                           @RequestBody CommentReactionRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -134,7 +134,7 @@ public class BookController {
     }
 
     // 한줄평 반응 수정 API
-    @PatchMapping("/modifyReaction/{isbn}")
+    @PatchMapping("/comment/reaction/{isbn}")
     public ResponseEntity modifyReaction(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                          @RequestBody CommentReactionRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -143,7 +143,7 @@ public class BookController {
     }
 
     // 한줄평 반응 삭제 API
-    @DeleteMapping("/deleteReaction/{isbn}")
+    @DeleteMapping("/comment/reaction/{isbn}")
     public ResponseEntity deleteReaction(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                          @RequestBody DeleteReactionRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -152,7 +152,7 @@ public class BookController {
     }
 
     // 신고하기 API
-    @PostMapping("/report/{isbn}")
+    @PostMapping("/comment/report/{isbn}")
     public ResponseEntity reportComment(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                         @RequestBody ReportCommentRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -161,7 +161,7 @@ public class BookController {
     }
 
     // 읽고싶은 책 등록 API
-    @PostMapping("/wantToRead/{isbn}")
+    @PostMapping("/want-to-read/{isbn}")
     public ResponseEntity wantToRead(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                      @RequestBody BookCreateRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -170,7 +170,7 @@ public class BookController {
     }
 
     // 읽기 시작한 날짜 변경 API
-    @PatchMapping("/modifyStartDate/{isbn}")
+    @PatchMapping("/start-date/{isbn}")
     public ResponseEntity modifyStartDate(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                           @RequestBody Map<String, String> startDateMap) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -179,7 +179,7 @@ public class BookController {
     }
 
     // 마지막 읽은 날짜 변경 API
-    @PatchMapping("/modifyRecentDate/{isbn}")
+    @PatchMapping("/recent-date/{isbn}")
     public ResponseEntity modifyRecentDate(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                            @RequestBody Map<String, String> recentDateMap) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -188,7 +188,7 @@ public class BookController {
     }
 
     // 책별 대표 위치 등록 API
-    @PostMapping("/mainLocation/{isbn}")
+    @PostMapping("/main-location/{isbn}")
     public ResponseEntity addMainLocation(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                           @RequestBody LocationRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -197,7 +197,7 @@ public class BookController {
     }
 
     // 책별 대표 위치 변경 API
-    @PatchMapping("/patchMainLocation/{isbn}")
+    @PatchMapping("/main-location/{isbn}")
     public ResponseEntity modifyMainLocation(@RequestHeader("xAuthToken") String token,
                                              @PathVariable("isbn") String isbn, @RequestBody LocationRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -206,7 +206,7 @@ public class BookController {
     }
 
     // 책별 대표 위치 삭제 API
-    @DeleteMapping("/deleteMainLocation/{isbn}")
+    @DeleteMapping("/main-location/{isbn}")
     public ResponseEntity deleteMainLocation(@RequestHeader("xAuthToken") String token,
                                              @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -215,8 +215,8 @@ public class BookController {
     }
 
     // 인물사전 등록 API
-    @PostMapping("/personalDictionary/{isbn}")
-    public ResponseEntity addpersonalDictionary(@RequestHeader("xAuthToken") String token,
+    @PostMapping("/character-dictionary/{isbn}")
+    public ResponseEntity addPersonalDictionary(@RequestHeader("xAuthToken") String token,
                                                 @PathVariable("isbn") String isbn,
                                                 @RequestBody PersonalDictionaryRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -225,7 +225,7 @@ public class BookController {
     }
 
     // 인물사전 수정 API
-    @PatchMapping("/modifyPersonalDictionary/{isbn}")
+    @PatchMapping("/character-dictionary/{isbn}")
     public ResponseEntity modifyPersonalDictionary(@RequestHeader("xAuthToken") String token,
                                                    @PathVariable("isbn") String isbn,
                                                    @RequestBody PersonalDictionaryRequest request) {
@@ -235,7 +235,7 @@ public class BookController {
     }
 
     // 인물사전 삭제 API
-    @DeleteMapping("/deletePersonalDictionary/{isbn}")
+    @DeleteMapping("/character-dictionary/{isbn}")
     public ResponseEntity deletePersonalDictionary(@RequestHeader("xAuthToken") String token,
                                                    @PathVariable("isbn") String isbn,
                                                    @RequestBody DeletePersonalDictionaryRequest request) {
@@ -245,7 +245,7 @@ public class BookController {
     }
 
     // 인물사전 전체조회 API
-    @GetMapping("/getPersonalDictionary/{isbn}")
+    @GetMapping("/character-dictionary/{isbn}")
     public ResponseEntity getPersonalDictionary(@RequestHeader("xAuthToken") String token,
                                                 @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -263,7 +263,7 @@ public class BookController {
     }
 
     // 메모 수정 API
-    @PatchMapping("/modifyMemo/{isbn}")
+    @PatchMapping("/memo/{isbn}")
     public ResponseEntity modifyMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                      @RequestBody MemoRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -272,7 +272,7 @@ public class BookController {
     }
 
     // 메모 삭제 API
-    @DeleteMapping("/deleteMemo/{isbn}")
+    @DeleteMapping("/memo/{isbn}")
     public ResponseEntity deleteMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                      @RequestBody DeleteUuidRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -281,7 +281,7 @@ public class BookController {
     }
 
     // 메모 전체조회 API
-    @GetMapping("/getMemo/{isbn}")
+    @GetMapping("/memo/{isbn}")
     public ResponseEntity getMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -298,7 +298,7 @@ public class BookController {
     }
 
     // 책갈피 수정 API
-    @PatchMapping("/modifyBookmark/{isbn}")
+    @PatchMapping("/bookmark/{isbn}")
     public ResponseEntity modifyBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                          @RequestBody BookmarkRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -307,7 +307,7 @@ public class BookController {
     }
 
     // 책갈피 삭제 API
-    @DeleteMapping("/deleteBookmark/{isbn}")
+    @DeleteMapping("/bookmark/{isbn}")
     public ResponseEntity deleteBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                          @RequestBody DeleteUuidRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -316,7 +316,7 @@ public class BookController {
     }
 
     // 책갈피 전체조회 API
-    @GetMapping("/getBookmark/{isbn}")
+    @GetMapping("/bookmark/{isbn}")
     public ResponseEntity getBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -324,7 +324,7 @@ public class BookController {
     }
 
     // 전체 위치 조회 API
-    @GetMapping("/getAllLocation/{orderNumber}")
+    @GetMapping("/map/location/{orderNumber}")
     public ResponseEntity getAllLocation(@RequestHeader("xAuthToken") String token,
                                          @PathVariable("orderNumber") Integer orderNumber) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -333,7 +333,7 @@ public class BookController {
     }
 
     // 최근 등록 위치 조회 API
-    @GetMapping("/getRecentLocation")
+    @GetMapping("/recent-location")
     public ResponseEntity getRecentLocation(@RequestHeader("xAuthToken") String token) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -341,7 +341,7 @@ public class BookController {
     }
 
     // 최근 등록 위치 삭제 API
-    @DeleteMapping("/deleteRecentLocation")
+    @DeleteMapping("/recent-location")
     public ResponseEntity deleteRecentLocation(@RequestHeader("xAuthToken") String token,
                                                @RequestBody DeleteRecentLocationRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -350,7 +350,7 @@ public class BookController {
     }
 
     // 지도 마크 조회 API
-    @GetMapping("/getAllMarker")
+    @GetMapping("/map/marker")
     public ResponseEntity getAllMarker(@RequestHeader("xAuthToken") String token) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -358,7 +358,7 @@ public class BookController {
     }
 
     // 마크 세부 조회 API
-    @GetMapping("/getMarkDetail")
+    @GetMapping("/map/marker/detail")
     public ResponseEntity getMarkDetail(@RequestHeader("xAuthToken") String token,
                                         @RequestParam("locationId") Long locationId,
                                         @RequestParam("orderNumber") Integer orderNumber) {

--- a/server/src/main/java/com/codecozy/server/controller/BookshelfController.java
+++ b/server/src/main/java/com/codecozy/server/controller/BookshelfController.java
@@ -18,18 +18,18 @@ public class BookshelfController {
     private final BookshelfService bookshelfService;
 
     // 책장 초기 조회
-    @GetMapping("/{bookshelfType}")
+    @GetMapping("/{type}")
     public ResponseEntity getAllBookshelf(@RequestHeader("xAuthToken") String token,
-                                          @PathVariable("bookshelfType") int bookshelfType) {
+                                          @PathVariable("type") int bookshelfType) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
         return bookshelfService.getAllBookshelf(memberId, bookshelfType);
     }
 
     // 책장 리스트용 조회
-    @GetMapping("/detail/{bookshelfCode}")
+    @GetMapping("/{code}/detail")
     public ResponseEntity getDetailBookshelf(@RequestHeader("xAuthToken") String token,
-                                             @PathVariable("bookshelfCode") String bookshelfCode) {
+                                             @PathVariable("code") String bookshelfCode) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
         return bookshelfService.getDetailBookshelf(memberId, bookshelfCode);

--- a/server/src/main/java/com/codecozy/server/controller/HomeController.java
+++ b/server/src/main/java/com/codecozy/server/controller/HomeController.java
@@ -30,9 +30,9 @@ public class HomeController {
     }
 
     // 검색
-    @GetMapping("/search/{searchText}")
+    @GetMapping("/search/{text}")
     public ResponseEntity getSearchList(@RequestHeader("xAuthToken") String token,
-            @PathVariable("searchText") String searchText) throws IOException {
+            @PathVariable("text") String searchText) throws IOException {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
         return homeService.getSearchList(memberId, searchText);
@@ -63,7 +63,7 @@ public class HomeController {
     }
 
     // 읽고 있는 책 숨기기 & 꺼내기
-    @PatchMapping("/hidden/{isbn}")
+    @PatchMapping("/{isbn}/hidden")
     public ResponseEntity modifyHidden(@RequestHeader("xAuthToken") String token,
             @PathVariable("isbn") String isbn, @RequestBody Map<String, Boolean> isHiddenMap) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);

--- a/server/src/main/java/com/codecozy/server/controller/HomeController.java
+++ b/server/src/main/java/com/codecozy/server/controller/HomeController.java
@@ -39,7 +39,7 @@ public class HomeController {
     }
 
     // 읽고 싶은 책 조회
-    @GetMapping("/wantToRead")
+    @GetMapping("/want-to-read")
     public ResponseEntity getWantToReadBooks(@RequestHeader("xAuthToken") String token) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -55,7 +55,7 @@ public class HomeController {
     }
 
     // 다 읽은 책 조회
-    @GetMapping("/finishRead")
+    @GetMapping("/finish-read")
     public ResponseEntity getFinishReadBooks(@RequestHeader("xAuthToken") String token) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -63,9 +63,9 @@ public class HomeController {
     }
 
     // 읽고 있는 책 숨기기 & 꺼내기
-    @PatchMapping("/hidden/{ISBN}")
+    @PatchMapping("/hidden/{isbn}")
     public ResponseEntity modifyHidden(@RequestHeader("xAuthToken") String token,
-            @PathVariable("ISBN") String isbn, @RequestBody Map<String, Boolean> isHiddenMap) {
+            @PathVariable("isbn") String isbn, @RequestBody Map<String, Boolean> isHiddenMap) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
         return homeService.modifyHidden(memberId, isbn, isHiddenMap.get("isHidden"));

--- a/server/src/main/java/com/codecozy/server/controller/MapController.java
+++ b/server/src/main/java/com/codecozy/server/controller/MapController.java
@@ -21,9 +21,9 @@ public class MapController {
     private final MapService mapService;
 
     // 전체 위치 조회 API
-    @GetMapping("/location/{orderNumber}")
+    @GetMapping("/location")
     public ResponseEntity getAllLocation(@RequestHeader("xAuthToken") String token,
-            @PathVariable("orderNumber") Integer orderNumber) {
+            @RequestParam("orderNumber") Integer orderNumber) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
         return mapService.getAllLocation(memberId, orderNumber);
@@ -38,9 +38,9 @@ public class MapController {
     }
 
     // 마크 세부 조회 API
-    @GetMapping("/marker/detail")
+    @GetMapping("/marker/{id}/detail")
     public ResponseEntity getMarkDetail(@RequestHeader("xAuthToken") String token,
-            @RequestParam("locationId") Long locationId,
+            @PathVariable("id") Long locationId,
             @RequestParam("orderNumber") Integer orderNumber) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
         MarkDetailRequest request = new MarkDetailRequest(locationId, orderNumber);

--- a/server/src/main/java/com/codecozy/server/controller/MapController.java
+++ b/server/src/main/java/com/codecozy/server/controller/MapController.java
@@ -1,0 +1,50 @@
+package com.codecozy.server.controller;
+
+import com.codecozy.server.dto.request.MarkDetailRequest;
+import com.codecozy.server.security.TokenProvider;
+import com.codecozy.server.service.MapService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/map")
+@RequiredArgsConstructor
+public class MapController {
+
+    private final TokenProvider tokenProvider;
+    private final MapService mapService;
+
+    // 전체 위치 조회 API
+    @GetMapping("/location/{orderNumber}")
+    public ResponseEntity getAllLocation(@RequestHeader("xAuthToken") String token,
+            @PathVariable("orderNumber") Integer orderNumber) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return mapService.getAllLocation(memberId, orderNumber);
+    }
+
+    // 지도 마크 조회 API
+    @GetMapping("/marker")
+    public ResponseEntity getAllMarker(@RequestHeader("xAuthToken") String token) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+
+        return mapService.getAllMarker(memberId);
+    }
+
+    // 마크 세부 조회 API
+    @GetMapping("/marker/detail")
+    public ResponseEntity getMarkDetail(@RequestHeader("xAuthToken") String token,
+            @RequestParam("locationId") Long locationId,
+            @RequestParam("orderNumber") Integer orderNumber) {
+        Long memberId = tokenProvider.getMemberIdFromToken(token);
+        MarkDetailRequest request = new MarkDetailRequest(locationId, orderNumber);
+
+        return mapService.getMarkDetail(memberId, request);
+    }
+}

--- a/server/src/main/java/com/codecozy/server/controller/MemberController.java
+++ b/server/src/main/java/com/codecozy/server/controller/MemberController.java
@@ -10,11 +10,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -55,8 +55,8 @@ public class MemberController {
     }
 
     // 닉네임 중복검사
-    @GetMapping("/nickname/validation/{nickname}")
-    public ResponseEntity validateNickname(@PathVariable("nickname") String nickname) {
+    @GetMapping("/nickname/check")
+    public ResponseEntity validateNickname(@RequestParam("nickname") String nickname) {
         return memberService.validateNickname(nickname);
     }
 

--- a/server/src/main/java/com/codecozy/server/controller/MemberController.java
+++ b/server/src/main/java/com/codecozy/server/controller/MemberController.java
@@ -14,15 +14,17 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/member")
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
 
     // 닉네임 중복검사
-    @GetMapping("/nickname/{nickname}")
+    @GetMapping("/nickname/validation/{nickname}")
     public ResponseEntity validateNickname(@PathVariable("nickname") String nickname) {
         return memberService.validateNickname(nickname);
     }
@@ -52,21 +54,21 @@ public class MemberController {
     }
 
     // 닉네임 변경
-    @PatchMapping("/nickname-modify")
+    @PatchMapping("/nickname")
     public ResponseEntity modifyNickname(@RequestHeader("xAuthToken") String token,
                                          @RequestBody Map<String, String> nicknameMap) {
         return memberService.modifyNickname(token, nicknameMap.get("nickname"));
     }
 
     // 프로필 이미지 변경
-    @PatchMapping("/profileImageCode")
+    @PatchMapping("/profile/image")
     public ResponseEntity modifyProfileImg(@RequestHeader("xAuthToken") String token,
                                            @RequestBody Map<String, String> profileCodeMap) {
         return memberService.modifyProfileImg(token, profileCodeMap.get("profileImageCode"));
     }
 
     // 회원 탈퇴
-    @DeleteMapping("/deleteAccount")
+    @DeleteMapping("")
     public ResponseEntity deleteMember(@RequestHeader("xAuthToken") String token) {
         return memberService.deleteMember(token);
     }
@@ -78,7 +80,7 @@ public class MemberController {
     }
 
     // 얻은 배지 조회
-    @GetMapping("/badge")
+    @GetMapping("/profile/badge")
     public ResponseEntity getBadgeList(@RequestHeader("xAuthToken") String token) {
         return memberService.getBadgeList(token);
     }

--- a/server/src/main/java/com/codecozy/server/controller/MemberController.java
+++ b/server/src/main/java/com/codecozy/server/controller/MemberController.java
@@ -21,13 +21,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/member")
 @RequiredArgsConstructor
 public class MemberController {
-    private final MemberService memberService;
 
-    // 닉네임 중복검사
-    @GetMapping("/nickname/validation/{nickname}")
-    public ResponseEntity validateNickname(@PathVariable("nickname") String nickname) {
-        return memberService.validateNickname(nickname);
-    }
+    private final MemberService memberService;
 
     // 카카오 회원가입
     @PostMapping("/sign-up/kakao")
@@ -53,6 +48,18 @@ public class MemberController {
         return memberService.signInApple(request);
     }
 
+    // 회원 탈퇴
+    @DeleteMapping("")
+    public ResponseEntity deleteMember(@RequestHeader("xAuthToken") String token) {
+        return memberService.deleteMember(token);
+    }
+
+    // 닉네임 중복검사
+    @GetMapping("/nickname/validation/{nickname}")
+    public ResponseEntity validateNickname(@PathVariable("nickname") String nickname) {
+        return memberService.validateNickname(nickname);
+    }
+
     // 닉네임 변경
     @PatchMapping("/nickname")
     public ResponseEntity modifyNickname(@RequestHeader("xAuthToken") String token,
@@ -60,23 +67,17 @@ public class MemberController {
         return memberService.modifyNickname(token, nicknameMap.get("nickname"));
     }
 
+    // 마이페이지 조회
+    @GetMapping("/profile")
+    public ResponseEntity getProfile(@RequestHeader("xAuthToken") String token) {
+        return memberService.getProfile(token);
+    }
+
     // 프로필 이미지 변경
     @PatchMapping("/profile/image")
     public ResponseEntity modifyProfileImg(@RequestHeader("xAuthToken") String token,
                                            @RequestBody Map<String, String> profileCodeMap) {
         return memberService.modifyProfileImg(token, profileCodeMap.get("profileImageCode"));
-    }
-
-    // 회원 탈퇴
-    @DeleteMapping("")
-    public ResponseEntity deleteMember(@RequestHeader("xAuthToken") String token) {
-        return memberService.deleteMember(token);
-    }
-
-    // 마이페이지 조회
-    @GetMapping("/profile")
-    public ResponseEntity getProfile(@RequestHeader("xAuthToken") String token) {
-        return memberService.getProfile(token);
     }
 
     // 얻은 배지 조회

--- a/server/src/main/java/com/codecozy/server/dto/request/DeleteRecentLocationRequest.java
+++ b/server/src/main/java/com/codecozy/server/dto/request/DeleteRecentLocationRequest.java
@@ -1,5 +1,0 @@
-package com.codecozy.server.dto.request;
-
-public record DeleteRecentLocationRequest(
-        long locationId
-) {}

--- a/server/src/main/java/com/codecozy/server/security/SecurityConfig.java
+++ b/server/src/main/java/com/codecozy/server/security/SecurityConfig.java
@@ -15,9 +15,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
     @Autowired
     private TokenProvider tokenProvider;
-    private final String[] allowedUrls = {"/", "/nickname/**", "/sign-up/**", "/sign-in/**"};
+    private final String[] allowedUrls = {"/member/nickname/validation/*",
+            "/member/sign-up/*", "/member/sign-in/*"};
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {

--- a/server/src/main/java/com/codecozy/server/security/SecurityConfig.java
+++ b/server/src/main/java/com/codecozy/server/security/SecurityConfig.java
@@ -18,8 +18,8 @@ public class SecurityConfig {
 
     @Autowired
     private TokenProvider tokenProvider;
-    private final String[] allowedUrls = {"/member/nickname/validation/*",
-            "/member/sign-up/*", "/member/sign-in/*"};
+    private final String[] allowedUrls = {"/member/sign-up/*", "/member/sign-in/*",
+            "/member/nickname/check"};
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1771,12 +1771,12 @@ public class BookService {
     }
 
     // 최근 등록 위치 삭제
-    public ResponseEntity<DefaultResponse> deleteRecentLocation(Long memberId, DeleteRecentLocationRequest request) {
+    public ResponseEntity<DefaultResponse> deleteRecentLocation(Long memberId, Long locationId) {
         // 사용자 받아오기
         Member member = memberRepository.findByMemberId(memberId);
 
         // 전체 위치에서 검색
-        LocationInfo locationInfo = locationInfoRepository.findByLocationId(request.locationId());
+        LocationInfo locationInfo = locationInfoRepository.findByLocationId(locationId);
         if (locationInfo != null) {
             // 최근 등록 위치에서 해당 위치가 있는지 확인하고 삭제
             MemberLocation memberLocation = memberLocationRepository.findByMemberAndLocationInfo(member,

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -30,7 +30,6 @@ import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -1742,37 +1741,6 @@ public class BookService {
                 HttpStatus.OK);
     }
 
-    // 전체 위치 조회
-    public ResponseEntity<DefaultResponse> getAllLocation(Long memberId, int orderNumber) {
-        // 응답으로 보낼 위치 리스트
-        List<LocationInfoDto> locationInfo = new ArrayList<>();
-
-        // 사용자 받아오기
-        Member member = memberRepository.findByMemberId(memberId);
-
-        // 조회할 위치가 더 있는지에 대한 flag
-        BooleanWrapper isBookRecordEnd = new BooleanWrapper();
-        isBookRecordEnd.setValue(false);
-        BooleanWrapper isBookmarkEnd = new BooleanWrapper();
-        isBookmarkEnd.setValue(false);
-
-        addLocationsAll(member, orderNumber, false, locationInfo, isBookRecordEnd);
-        addLocationsAll(member, orderNumber, true, locationInfo, isBookmarkEnd);
-
-        if (locationInfo.isEmpty()) {
-            return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_LOCATION.get()),
-                    HttpStatus.NOT_FOUND);
-        }
-
-        AllLocationResponse allLocationResponse = new AllLocationResponse(locationInfo,
-                (isBookRecordEnd.getValue() && isBookmarkEnd.getValue()));
-
-        return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), allLocationResponse),
-                HttpStatus.OK);
-    }
-
     // 최근 등록 위치 조회
     public ResponseEntity<DefaultResponse> getRecentLocation(Long memberId) {
         // 응답으로 보낼 객체 리스트
@@ -1840,90 +1808,7 @@ public class BookService {
                 HttpStatus.OK);
     }
 
-    // 지도 마크 조회
-    public ResponseEntity<DefaultResponse> getAllMarker(Long memberId) {
-        // 사용자 받아오기
-        Member member = memberRepository.findByMemberId(memberId);
-
-        // 독서노트의 대표위치, 책갈피의 위치를 가져와 리스트 생성
-        List<AllMarkerResponse> allMarkers = Stream.concat(
-                member.getBookRecords().stream()
-                        .map(bookRecord -> new AllMarkerResponse(
-                                bookRecord.getLocationInfo().getLocationId(),
-                                bookRecord.getLocationInfo().getLatitude(),
-                                bookRecord.getLocationInfo().getLongitude(),
-                                false)),
-                bookmarkRepository.findAllByBookRecordMember(member).stream()
-                        .map(bookmark -> new AllMarkerResponse(
-                                bookmark.getLocationInfo().getLocationId(),
-                                bookmark.getLocationInfo().getLatitude(),
-                                bookmark.getLocationInfo().getLongitude(),
-                                true
-                        ))
-        ).collect(Collectors.toList());
-
-        if (allMarkers.isEmpty()) { // 조회할 마크가 하나도 없는 경우
-            return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_MARKER.get()),
-                    HttpStatus.NOT_FOUND);
-        }
-
-        return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), allMarkers),
-                HttpStatus.OK);
-    }
-
-    // 마크 세부 조회
-    public ResponseEntity<DefaultResponse> getMarkDetail(Long memberId, MarkDetailRequest request) {
-        // 응답으로 보낼 위치 리스트
-        List<LocationInfoDto> locationInfoList = new ArrayList<>();
-
-        // 사용자 받아오기
-        Member member = memberRepository.findByMemberId(memberId);
-
-        int orderNumber = request.orderNumber();
-        long locationId = request.locationId();
-
-        // 조회할 위치가 더 있는지에 대한 flag
-        BooleanWrapper isBookRecordEnd = new BooleanWrapper();
-        isBookRecordEnd.setValue(false);
-        BooleanWrapper isBookmarkEnd = new BooleanWrapper();
-        isBookmarkEnd.setValue(false);
-
-        // locationId로 위치 정보 검색
-        LocationInfo locationInfo = locationInfoRepository.findByLocationId(locationId);
-
-        // 독서노트, 북마크에서 위치 정보를 가져오는 메소드 호출
-        addLocations(member, locationInfo, orderNumber, false, locationInfoList, isBookRecordEnd);
-        addLocations(member, locationInfo, orderNumber, true, locationInfoList, isBookmarkEnd);
-
-        if (locationInfoList.isEmpty()) { // 세부 조회할 마크가 하나도 없는 경우
-            return new ResponseEntity<>(
-                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_MARKER_TO_DETAIL.get()),
-                    HttpStatus.NOT_FOUND);
-        }
-
-        return new ResponseEntity<>(
-                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(),
-                        new AllLocationResponse(locationInfoList,
-                                (isBookRecordEnd.getValue() && isBookmarkEnd.getValue()))),
-                HttpStatus.OK);
-    }
-
     /** 헬퍼 클래스 및 메소드 **/
-
-    // Boolean을 참조 타입으로 전달하기 위한 클래스
-    private class BooleanWrapper {
-        private boolean value;
-
-        public boolean getValue() {
-            return value;
-        }
-
-        public void setValue(boolean value) {
-            this.value = value;
-        }
-    }
 
     // 중복 책 검색 및 등록
     private Book registerBook(String isbn, BookCreateRequest bookInformation) {
@@ -1948,127 +1833,6 @@ public class BookService {
         }
 
         memberLocationRepository.save(MemberLocation.create(member, locationInfo, LocalDateTime.now()));
-    }
-
-    // 전체 위치 조회를 위한 독서노트, 책갈피에서의 위치 정보 조회
-    private void addLocationsAll(Member member, int orderNumber, boolean isBookmark, List<LocationInfoDto> locationInfo,
-                                BooleanWrapper isEnd) {
-        // 정보 받아오기
-        List<?> records = isBookmark ? bookmarkRepository.findAllByBookRecordMember(member) : member.getBookRecords();
-
-        int size = records.size();
-        BookRecord bookRecord;
-        Bookmark bookmark;
-
-        for (int i = (orderNumber * 20); i < 20 + (orderNumber * 20); i++) {
-            // 이번이 마지막 조회면 (전체 개수와 이번 orderNumber를 사용하여 비교)
-            if ((orderNumber + 1) * 20 >= size) {
-                isEnd.setValue(true);
-            }
-
-            // 현재 조회하는 컬럼이 받아온 컬럼들의 사이즈보다 같거나 크면 break
-            if (i >= size) {
-                break;
-            }
-
-            // Response 전달 시 들어가는 데이터
-            String date;
-            String title;
-            int readPage;
-            long locationId;
-            String placeName;
-
-            if (isBookmark) { // 책갈피면
-                bookmark = (Bookmark) records.get(i);
-                if (bookmark.getLocationInfo() == null) {
-                    break;
-                }
-
-                // 책갈피에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
-                date = converterService.dateToString(bookmark.getDate());
-                title = bookmark.getBookRecord().getBook().getTitle();
-                readPage = bookmark.getMarkPage();
-                locationId = bookmark.getLocationInfo().getLocationId();
-                placeName = bookmark.getLocationInfo().getPlaceName();
-
-            } else { // 독서노트면
-                bookRecord = (BookRecord) records.get(i);
-                if (bookRecord.getLocationInfo() == null) {
-                    break;
-                }
-
-                // 독서노트에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
-                date = converterService.dateToString(bookRecord.getStartDate());
-                title = bookRecord.getBook().getTitle();
-                readPage = bookRecord.getMarkPage();
-                locationId = bookRecord.getLocationInfo().getLocationId();
-                placeName = bookRecord.getLocationInfo().getPlaceName();
-            }
-
-            // 받아온 정보로 위치 정보 추가
-            locationInfo.add(new LocationInfoDto(date, isBookmark, title, readPage, locationId, placeName));
-        }
-    }
-
-    // 마크 세부 조회를 위한 독서노트, 책갈피에서의 위치 정보 조회
-    private void addLocations(Member member, LocationInfo locationInfo, int orderNumber, boolean isBookmark,
-                             List<LocationInfoDto> locationInfoList, BooleanWrapper isEnd) {
-        // 북마크인지 여부에 따라 필요한 레포지토리 검색
-        List<?> records = isBookmark ? bookmarkRepository.findAllByBookRecordMemberAndLocationInfo(member, locationInfo)
-                : bookRecordRepository.findAllByMemberAndLocationInfo(member, locationInfo);
-
-        int size = records.size();
-        BookRecord bookRecord;
-        Bookmark bookmark;
-
-        for (int i = (orderNumber * 20); i < 20 + (orderNumber * 20); i++) {
-            // 이번이 마지막 조회면 (전체 개수와 이번 orderNumber를 사용하여 비교)
-            if ((orderNumber + 1) * 20 >= size) {
-                isEnd.setValue(true);
-            }
-
-            // 현재 조회하는 컬럼이 받아온 컬럼들의 사이즈보다 같거나 크면 break
-            if (i >= size) {
-                break;
-            }
-
-            // Response 전달 시 들어가는 데이터
-            String date;
-            String title;
-            int readPage;
-            long locationId;
-            String placeName;
-
-            if (isBookmark) { // 책갈피면
-                bookmark = (Bookmark) records.get(i);
-                if (bookmark.getLocationInfo() == null) {
-                    break;
-                }
-
-                // 책갈피에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
-                date = converterService.dateToString(bookmark.getDate());
-                title = bookmark.getBookRecord().getBook().getTitle();
-                readPage = bookmark.getMarkPage();
-                locationId = bookmark.getLocationInfo().getLocationId();
-                placeName = bookmark.getLocationInfo().getPlaceName();
-
-            } else { // 독서노트면
-                bookRecord = (BookRecord) records.get(i);
-                if (bookRecord.getLocationInfo() == null) {
-                    break;
-                }
-
-                // 독서노트에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
-                date = converterService.dateToString(bookRecord.getStartDate());
-                title = bookRecord.getBook().getTitle();
-                readPage = bookRecord.getMarkPage();
-                locationId = bookRecord.getLocationInfo().getLocationId();
-                placeName = bookRecord.getLocationInfo().getPlaceName();
-            }
-
-            // 받아온 정보로 위치 정보 추가
-            locationInfoList.add(new LocationInfoDto(date, isBookmark, title, readPage, locationId, placeName));
-        }
     }
 
     // 한줄평에 대한 반응 레코드 등록(BookReviewReaction)

--- a/server/src/main/java/com/codecozy/server/service/MapService.java
+++ b/server/src/main/java/com/codecozy/server/service/MapService.java
@@ -1,0 +1,273 @@
+package com.codecozy.server.service;
+
+import com.codecozy.server.context.ResponseMessages;
+import com.codecozy.server.context.StatusCode;
+import com.codecozy.server.dto.request.MarkDetailRequest;
+import com.codecozy.server.dto.response.AllLocationResponse;
+import com.codecozy.server.dto.response.AllMarkerResponse;
+import com.codecozy.server.dto.response.DefaultResponse;
+import com.codecozy.server.dto.response.LocationInfoDto;
+import com.codecozy.server.entity.BookRecord;
+import com.codecozy.server.entity.Bookmark;
+import com.codecozy.server.entity.LocationInfo;
+import com.codecozy.server.entity.Member;
+import com.codecozy.server.repository.BookRecordRepository;
+import com.codecozy.server.repository.BookmarkRepository;
+import com.codecozy.server.repository.LocationInfoRepository;
+import com.codecozy.server.repository.MemberRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MapService {
+
+    private final ConverterService converterService;
+    private final MemberRepository memberRepository;
+    private final BookRecordRepository bookRecordRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final LocationInfoRepository locationInfoRepository;
+
+    // 전체 위치 조회
+    public ResponseEntity<DefaultResponse> getAllLocation(Long memberId, int orderNumber) {
+        // 응답으로 보낼 위치 리스트
+        List<LocationInfoDto> locationInfo = new ArrayList<>();
+
+        // 사용자 받아오기
+        Member member = memberRepository.findByMemberId(memberId);
+
+        // 조회할 위치가 더 있는지에 대한 flag
+        BooleanWrapper isBookRecordEnd = new BooleanWrapper();
+        isBookRecordEnd.setValue(false);
+        BooleanWrapper isBookmarkEnd = new BooleanWrapper();
+        isBookmarkEnd.setValue(false);
+
+        addLocationsAll(member, orderNumber, false, locationInfo, isBookRecordEnd);
+        addLocationsAll(member, orderNumber, true, locationInfo, isBookmarkEnd);
+
+        if (locationInfo.isEmpty()) {
+            return new ResponseEntity<>(
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_LOCATION.get()),
+                    HttpStatus.NOT_FOUND);
+        }
+
+        AllLocationResponse allLocationResponse = new AllLocationResponse(locationInfo,
+                (isBookRecordEnd.getValue() && isBookmarkEnd.getValue()));
+
+        return new ResponseEntity<>(
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), allLocationResponse),
+                HttpStatus.OK);
+    }
+
+    // 지도 마크 조회
+    public ResponseEntity<DefaultResponse> getAllMarker(Long memberId) {
+        // 사용자 받아오기
+        Member member = memberRepository.findByMemberId(memberId);
+
+        // 독서노트의 대표위치, 책갈피의 위치를 가져와 리스트 생성
+        List<AllMarkerResponse> allMarkers = Stream.concat(
+                member.getBookRecords().stream()
+                      .map(bookRecord -> new AllMarkerResponse(
+                              bookRecord.getLocationInfo().getLocationId(),
+                              bookRecord.getLocationInfo().getLatitude(),
+                              bookRecord.getLocationInfo().getLongitude(),
+                              false)),
+                bookmarkRepository.findAllByBookRecordMember(member).stream()
+                                  .map(bookmark -> new AllMarkerResponse(
+                                          bookmark.getLocationInfo().getLocationId(),
+                                          bookmark.getLocationInfo().getLatitude(),
+                                          bookmark.getLocationInfo().getLongitude(),
+                                          true
+                                  ))
+        ).collect(Collectors.toList());
+
+        if (allMarkers.isEmpty()) { // 조회할 마크가 하나도 없는 경우
+            return new ResponseEntity<>(
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_MARKER.get()),
+                    HttpStatus.NOT_FOUND);
+        }
+
+        return new ResponseEntity<>(
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), allMarkers),
+                HttpStatus.OK);
+    }
+
+    // 마크 세부 조회
+    public ResponseEntity<DefaultResponse> getMarkDetail(Long memberId, MarkDetailRequest request) {
+        // 응답으로 보낼 위치 리스트
+        List<LocationInfoDto> locationInfoList = new ArrayList<>();
+
+        // 사용자 받아오기
+        Member member = memberRepository.findByMemberId(memberId);
+
+        int orderNumber = request.orderNumber();
+        long locationId = request.locationId();
+
+        // 조회할 위치가 더 있는지에 대한 flag
+        BooleanWrapper isBookRecordEnd = new BooleanWrapper();
+        isBookRecordEnd.setValue(false);
+        BooleanWrapper isBookmarkEnd = new BooleanWrapper();
+        isBookmarkEnd.setValue(false);
+
+        // locationId로 위치 정보 검색
+        LocationInfo locationInfo = locationInfoRepository.findByLocationId(locationId);
+
+        // 독서노트, 북마크에서 위치 정보를 가져오는 메소드 호출
+        addLocations(member, locationInfo, orderNumber, false, locationInfoList, isBookRecordEnd);
+        addLocations(member, locationInfo, orderNumber, true, locationInfoList, isBookmarkEnd);
+
+        if (locationInfoList.isEmpty()) { // 세부 조회할 마크가 하나도 없는 경우
+            return new ResponseEntity<>(
+                    DefaultResponse.from(StatusCode.NOT_FOUND, ResponseMessages.NOT_FOUND_MARKER_TO_DETAIL.get()),
+                    HttpStatus.NOT_FOUND);
+        }
+
+        return new ResponseEntity<>(
+                DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(),
+                        new AllLocationResponse(locationInfoList,
+                                (isBookRecordEnd.getValue() && isBookmarkEnd.getValue()))),
+                HttpStatus.OK);
+    }
+
+    /** 헬퍼 클래스 및 메소드 **/
+
+    // Boolean을 참조 타입으로 전달하기 위한 클래스
+    private class BooleanWrapper {
+        private boolean value;
+
+        public boolean getValue() {
+            return value;
+        }
+
+        public void setValue(boolean value) {
+            this.value = value;
+        }
+    }
+
+    // 전체 위치 조회를 위한 독서노트, 책갈피에서의 위치 정보 조회
+    private void addLocationsAll(Member member, int orderNumber, boolean isBookmark, List<LocationInfoDto> locationInfo,
+            BooleanWrapper isEnd) {
+        // 정보 받아오기
+        List<?> records = isBookmark ? bookmarkRepository.findAllByBookRecordMember(member) : member.getBookRecords();
+
+        int size = records.size();
+        BookRecord bookRecord;
+        Bookmark bookmark;
+
+        for (int i = (orderNumber * 20); i < 20 + (orderNumber * 20); i++) {
+            // 이번이 마지막 조회면 (전체 개수와 이번 orderNumber를 사용하여 비교)
+            if ((orderNumber + 1) * 20 >= size) {
+                isEnd.setValue(true);
+            }
+
+            // 현재 조회하는 컬럼이 받아온 컬럼들의 사이즈보다 같거나 크면 break
+            if (i >= size) {
+                break;
+            }
+
+            // Response 전달 시 들어가는 데이터
+            String date;
+            String title;
+            int readPage;
+            long locationId;
+            String placeName;
+
+            if (isBookmark) { // 책갈피면
+                bookmark = (Bookmark) records.get(i);
+                if (bookmark.getLocationInfo() == null) {
+                    break;
+                }
+
+                // 책갈피에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
+                date = converterService.dateToString(bookmark.getDate());
+                title = bookmark.getBookRecord().getBook().getTitle();
+                readPage = bookmark.getMarkPage();
+                locationId = bookmark.getLocationInfo().getLocationId();
+                placeName = bookmark.getLocationInfo().getPlaceName();
+
+            } else { // 독서노트면
+                bookRecord = (BookRecord) records.get(i);
+                if (bookRecord.getLocationInfo() == null) {
+                    break;
+                }
+
+                // 독서노트에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
+                date = converterService.dateToString(bookRecord.getStartDate());
+                title = bookRecord.getBook().getTitle();
+                readPage = bookRecord.getMarkPage();
+                locationId = bookRecord.getLocationInfo().getLocationId();
+                placeName = bookRecord.getLocationInfo().getPlaceName();
+            }
+
+            // 받아온 정보로 위치 정보 추가
+            locationInfo.add(new LocationInfoDto(date, isBookmark, title, readPage, locationId, placeName));
+        }
+    }
+
+    // 마크 세부 조회를 위한 독서노트, 책갈피에서의 위치 정보 조회
+    private void addLocations(Member member, LocationInfo locationInfo, int orderNumber, boolean isBookmark,
+            List<LocationInfoDto> locationInfoList, BooleanWrapper isEnd) {
+        // 북마크인지 여부에 따라 필요한 레포지토리 검색
+        List<?> records = isBookmark ? bookmarkRepository.findAllByBookRecordMemberAndLocationInfo(member, locationInfo)
+                : bookRecordRepository.findAllByMemberAndLocationInfo(member, locationInfo);
+
+        int size = records.size();
+        BookRecord bookRecord;
+        Bookmark bookmark;
+
+        for (int i = (orderNumber * 20); i < 20 + (orderNumber * 20); i++) {
+            // 이번이 마지막 조회면 (전체 개수와 이번 orderNumber를 사용하여 비교)
+            if ((orderNumber + 1) * 20 >= size) {
+                isEnd.setValue(true);
+            }
+
+            // 현재 조회하는 컬럼이 받아온 컬럼들의 사이즈보다 같거나 크면 break
+            if (i >= size) {
+                break;
+            }
+
+            // Response 전달 시 들어가는 데이터
+            String date;
+            String title;
+            int readPage;
+            long locationId;
+            String placeName;
+
+            if (isBookmark) { // 책갈피면
+                bookmark = (Bookmark) records.get(i);
+                if (bookmark.getLocationInfo() == null) {
+                    break;
+                }
+
+                // 책갈피에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
+                date = converterService.dateToString(bookmark.getDate());
+                title = bookmark.getBookRecord().getBook().getTitle();
+                readPage = bookmark.getMarkPage();
+                locationId = bookmark.getLocationInfo().getLocationId();
+                placeName = bookmark.getLocationInfo().getPlaceName();
+
+            } else { // 독서노트면
+                bookRecord = (BookRecord) records.get(i);
+                if (bookRecord.getLocationInfo() == null) {
+                    break;
+                }
+
+                // 독서노트에서 날짜, 제목, 읽은 페이지, 위치 아이디, 장소명을 받아오기
+                date = converterService.dateToString(bookRecord.getStartDate());
+                title = bookRecord.getBook().getTitle();
+                readPage = bookRecord.getMarkPage();
+                locationId = bookRecord.getLocationInfo().getLocationId();
+                placeName = bookRecord.getLocationInfo().getPlaceName();
+            }
+
+            // 받아온 정보로 위치 정보 추가
+            locationInfoList.add(new LocationInfoDto(date, isBookmark, title, readPage, locationId, placeName));
+        }
+    }
+}


### PR DESCRIPTION
## 목적🎯
- 대부분의 URL이 RESTful하지 못한 것을 확인, RESTful한 API로 만들기 위함 

## 변경사항🛠️
- 최대한 리소스 기준, 계층적으로 표현함
- 식별자의 의미로 사용될 때만 PathVariable을 사용하도록 변경, 그 외 용도로 사용되는 파라미터는 QueryString으로 변경
- 책지도 관련 API는 독서노트 페이지와는 다른 계열이므로 가독성과 명확성을 위해 분리함

## 수행한 테스트✏️
X

## 비고📌
- 현재 어떤 URL로 변경했는지에 대해서는 엑셀 문서로만 정리한 상태이며, 이는 디스코드에 공유해놓겠습니다!
- 노션 API 문서와 Postman은 다음주 중으로 차차 수정하겠습니다 :)