### PR TITLE
BooleanWrapper 클래스 제거 및 Member 객체 캐시 사용

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -49,6 +49,10 @@ dependencies {
 
 	// JSON 데이터 처리 라이브러리
 	implementation group: 'org.json', name: 'json', version: '20230618'
+	
+	// 캐시 처리 라이브러리
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.6'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/codecozy/server/ServerApplication.java
+++ b/server/src/main/java/com/codecozy/server/ServerApplication.java
@@ -2,8 +2,10 @@ package com.codecozy.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/server/src/main/java/com/codecozy/server/dto/response/DetailBookshelfResponse.java
+++ b/server/src/main/java/com/codecozy/server/dto/response/DetailBookshelfResponse.java
@@ -4,6 +4,7 @@ public record DetailBookshelfResponse(
         String ISBN,
         String cover,
         String title,
+        String author,
         Integer bookType,
         int category,
         boolean isMine,

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -144,7 +143,7 @@ public class BookService {
     // 독서노트 조회
     public ResponseEntity<DefaultResponse> getReadingNote(Long memberId, String isbn) {
         // 사용자 받아오기
-        Member member = getMemberById(memberId);
+        Member member = memberRepository.findByMemberId(memberId);
 
         // 해당 책 찾기
         Book book = bookRepository.findByIsbn(isbn);
@@ -368,7 +367,7 @@ public class BookService {
         SearchBookResponse response = dataParsing(jsonResponse);
 
         // 사용자 받아오기
-        Member member = getMemberById(memberId);
+        Member member = memberRepository.findByMemberId(memberId);
 
         // 해당 책 찾기
         Book book = bookRepository.findByIsbn(isbn);
@@ -402,7 +401,7 @@ public class BookService {
     // 한줄평 추가조회
     public ResponseEntity<DefaultResponse> commentDetail(Long memberId, String isbn, CommentDetailRequest request) {
         // 사용자 받아오기
-        Member member = getMemberById(memberId);
+        Member member = memberRepository.findByMemberId(memberId);
 
         // 해당 책 찾기
         Book book = bookRepository.findByIsbn(isbn);
@@ -1324,7 +1323,7 @@ public class BookService {
         List<PersonalDictionaryResponse> personalDictionaryList = new ArrayList<>();
 
         // 사용자 받아오기
-        Member member = getMemberById(memberId);
+        Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
@@ -1460,7 +1459,7 @@ public class BookService {
         List<MemoResponse> memoList = new ArrayList<>();
 
         // 사용자 받아오기
-        Member member = getMemberById(memberId);
+        Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
@@ -1705,7 +1704,7 @@ public class BookService {
         List<BookmarkResponse> bookmarkList = new ArrayList<>();
 
         // 사용자 받아오기
-        Member member = getMemberById(memberId);
+        Member member = memberRepository.findByMemberId(memberId);
 
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
@@ -1750,7 +1749,7 @@ public class BookService {
         List<RecentLocationResponse> location = new ArrayList<>();
 
         // 사용자 받아오기
-        Member member = getMemberById(memberId);
+        Member member = memberRepository.findByMemberId(memberId);
 
         // 사용자별 등록 위치 받아오기
         List<MemberLocation> memberLocationList = member.getMemberLocations();
@@ -1981,7 +1980,6 @@ public class BookService {
                 .collect(Collectors.toList());
     }
 
-    private final CacheManager cacheManager;
     @Cacheable(value = "member", key = "#memberId")
     private Member getMemberById(Long memberId) {
         return memberRepository.findByMemberId(memberId);

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -70,7 +70,7 @@ public class BookService {
 
         // memberId와 isbn을 이용해 사용자별 리뷰 등록 책이 중복되었는지 검사
         BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
-        if (bookRecord != null && bookRecord.getBookType() != -1) { // -1: reading_status가 '읽고싶은'(0)인 경우
+        if (bookRecord != null && bookRecord.getBookType() != -1) { // reading_status가 '읽고싶은'(0)인 경우, bookType이 -1로 생성됨
             return new ResponseEntity<>(
                     DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_BOOK_RECORD.get()),
                     HttpStatus.CONFLICT);

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -10,11 +10,14 @@ import com.codecozy.server.repository.*;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -141,7 +144,7 @@ public class BookService {
     // 독서노트 조회
     public ResponseEntity<DefaultResponse> getReadingNote(Long memberId, String isbn) {
         // 사용자 받아오기
-        Member member = memberRepository.findByMemberId(memberId);
+        Member member = getMemberById(memberId);
 
         // 해당 책 찾기
         Book book = bookRepository.findByIsbn(isbn);
@@ -365,7 +368,7 @@ public class BookService {
         SearchBookResponse response = dataParsing(jsonResponse);
 
         // 사용자 받아오기
-        Member member = memberRepository.findByMemberId(memberId);
+        Member member = getMemberById(memberId);
 
         // 해당 책 찾기
         Book book = bookRepository.findByIsbn(isbn);
@@ -399,7 +402,7 @@ public class BookService {
     // 한줄평 추가조회
     public ResponseEntity<DefaultResponse> commentDetail(Long memberId, String isbn, CommentDetailRequest request) {
         // 사용자 받아오기
-        Member member = memberRepository.findByMemberId(memberId);
+        Member member = getMemberById(memberId);
 
         // 해당 책 찾기
         Book book = bookRepository.findByIsbn(isbn);
@@ -1321,7 +1324,7 @@ public class BookService {
         List<PersonalDictionaryResponse> personalDictionaryList = new ArrayList<>();
 
         // 사용자 받아오기
-        Member member = memberRepository.findByMemberId(memberId);
+        Member member = getMemberById(memberId);
 
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
@@ -1457,7 +1460,7 @@ public class BookService {
         List<MemoResponse> memoList = new ArrayList<>();
 
         // 사용자 받아오기
-        Member member = memberRepository.findByMemberId(memberId);
+        Member member = getMemberById(memberId);
 
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
@@ -1702,7 +1705,7 @@ public class BookService {
         List<BookmarkResponse> bookmarkList = new ArrayList<>();
 
         // 사용자 받아오기
-        Member member = memberRepository.findByMemberId(memberId);
+        Member member = getMemberById(memberId);
 
         // isbn으로 책 검색
         Book book = bookRepository.findByIsbn(isbn);
@@ -1747,7 +1750,7 @@ public class BookService {
         List<RecentLocationResponse> location = new ArrayList<>();
 
         // 사용자 받아오기
-        Member member = memberRepository.findByMemberId(memberId);
+        Member member = getMemberById(memberId);
 
         // 사용자별 등록 위치 받아오기
         List<MemberLocation> memberLocationList = member.getMemberLocations();
@@ -1976,5 +1979,11 @@ public class BookService {
                 .map(BookReview::getReviewText)
                 .limit(5)
                 .collect(Collectors.toList());
+    }
+
+    private final CacheManager cacheManager;
+    @Cacheable(value = "member", key = "#memberId")
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findByMemberId(memberId);
     }
 }

--- a/server/src/main/java/com/codecozy/server/service/BookshelfService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookshelfService.java
@@ -209,6 +209,7 @@ public class BookshelfService {
                     detailBookshelfResponseList.add(new DetailBookshelfResponse(
                             bookRecord.getBook().getIsbn(),
                             bookRecord.getBook().getCover(),
+                            bookRecord.getBook().getTitle(),
                             bookRecord.getBook().getAuthor(),
                             null,
                             converterService.categoryNameToCode(bookRecord.getBook().getCategory()),
@@ -236,6 +237,7 @@ public class BookshelfService {
                     detailBookshelfResponseList.add(new DetailBookshelfResponse(
                             bookRecord.getBook().getIsbn(),
                             bookRecord.getBook().getCover(),
+                            bookRecord.getBook().getTitle(),
                             bookRecord.getBook().getAuthor(),
                             bookRecord.getBookType(),
                             converterService.categoryNameToCode(bookRecord.getBook().getCategory()),
@@ -263,6 +265,7 @@ public class BookshelfService {
                     detailBookshelfResponseList.add(new DetailBookshelfResponse(
                             bookRecord.getBook().getIsbn(),
                             bookRecord.getBook().getCover(),
+                            bookRecord.getBook().getTitle(),
                             bookRecord.getBook().getAuthor(),
                             bookRecord.getBookType(),
                             converterService.categoryNameToCode(bookRecord.getBook().getCategory()),

--- a/server/src/main/java/com/codecozy/server/service/MemberService.java
+++ b/server/src/main/java/com/codecozy/server/service/MemberService.java
@@ -20,6 +20,7 @@ import com.codecozy.server.security.TokenProvider;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -176,6 +177,7 @@ public class MemberService {
     }
 
     // 회원 탈퇴
+    @CacheEvict(value = "member", key = "#memberId") // 캐시된 데이터 삭제
     public ResponseEntity<DefaultResponse> deleteMember(String token) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 

--- a/server/src/main/java/com/codecozy/server/service/MemberService.java
+++ b/server/src/main/java/com/codecozy/server/service/MemberService.java
@@ -20,7 +20,7 @@ import com.codecozy.server.security.TokenProvider;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -177,7 +177,6 @@ public class MemberService {
     }
 
     // 회원 탈퇴
-    @CacheEvict(value = "member", key = "#memberId") // 캐시된 데이터 삭제
     public ResponseEntity<DefaultResponse> deleteMember(String token) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
 
@@ -255,5 +254,10 @@ public class MemberService {
 
         return new ResponseEntity<>(DefaultResponse.from(StatusCode.OK, ResponseMessages.SUCCESS.get(), badgeResponseList),
                 HttpStatus.OK);
+    }
+
+    @Cacheable(value = "member", key = "#memberId")
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findByMemberId(memberId);
     }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -26,6 +26,12 @@ spring:
     ansi:
       enabled: always
 
+  # 캐시 구현체 Caffeine 설정
+  cache:
+    type: caffeine
+    caffeine:
+      spec: "expireAfterWrite=10m,maximumSize=100"
+
 # 로그 레벨 설정
 logging:
   level:


### PR DESCRIPTION
## 목적🎯
 - boolean 값을 참조 객체로 사용하기 위해 만들었던 BooleanWrapper 클래스 삭제
 - 자주 사용할 것 같은 객체를 캐시로 사용하여 DB 접근 횟수 줄이기

## 변경사항🛠️
 - 혼동 가능성이 있는 주석 수정
 - BooleanWrapper 클래스 삭제 및 AtomicBoolean 클래스로 수정
 - memberId에 기반한 Member 객체 Caffeine 캐시로 활용

## 수행한 테스트✏️
 - AtomicBoolean이 사용된 전체 위치 조회, 마크 세부 조회 API Postman으로 테스트
 - 캐시 사용 로직마다 로그를 찍어보며 캐시가 사용되는지 테스트
 - 캐시 삭제 로직(회원 탈퇴)에 로그를 찍어 캐시가 정상적으로 삭제됐는지 테스트

## 비고📌
저번에 말씀주셨던 Cascade 설정에 따른 명시적 삭제 코드 검토도 진행해봤는데, 제가 못 찾은건지.. 수정할만한 부분은 찾지 못했습니다! Cascade 설정된 데이터들은 명시적으로 확인하고 삭제하는 코드가 없더라구요..!! 혹시 코드 보다가 찾으면 그때그때 추가해서 올려놓겠습니다!