### PR TITLE
캐시 매니저 설정 및 테스트 코드 추가

### DIFF
--- a/server/src/main/java/com/codecozy/server/cache/MemberCacheManager.java
+++ b/server/src/main/java/com/codecozy/server/cache/MemberCacheManager.java
@@ -3,9 +3,11 @@ package com.codecozy.server.cache;
 import com.codecozy.server.entity.Member;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
+@Component
 public class MemberCacheManager {
     private final Cache<Long, Member> memberCache;
 

--- a/server/src/main/java/com/codecozy/server/cache/MemberCacheManager.java
+++ b/server/src/main/java/com/codecozy/server/cache/MemberCacheManager.java
@@ -1,0 +1,39 @@
+package com.codecozy.server.cache;
+
+import com.codecozy.server.entity.Member;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import java.util.concurrent.TimeUnit;
+
+public class MemberCacheManager {
+    private final Cache<Long, Member> memberCache;
+
+    // 캐시 만료 시간과 크기 설정
+    public MemberCacheManager() {
+        this.memberCache = Caffeine.newBuilder()
+                .expireAfterWrite(30, TimeUnit.MINUTES)
+                .maximumSize(200)
+                .build();
+    }
+
+    // 캐시 데이터 추가
+    public void put(Long memberId, Member member) {
+        memberCache.put(memberId, member);
+    }
+
+    // 캐시 데이터 조회
+    public Member get(Long memberId) {
+        return memberCache.getIfPresent(memberId);
+    }
+
+    // 캐시 데이터 삭제
+    public void remove(Long memberId) {
+        memberCache.invalidate(memberId);
+    }
+
+    // 캐시 전체 비우기
+    public void clearCache() {
+        memberCache.invalidateAll();
+    }
+}

--- a/server/src/test/java/com/codecozy/server/cache/MemberCacheManagerTest.java
+++ b/server/src/test/java/com/codecozy/server/cache/MemberCacheManagerTest.java
@@ -4,10 +4,17 @@ import com.codecozy.server.entity.Member;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.annotation.EnableCaching;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SpringBootTest
+@EnableCaching
 class MemberCacheManagerTest {
 
+    @Autowired
     private MemberCacheManager memberCacheManager;
 
     private Member member;
@@ -17,7 +24,7 @@ class MemberCacheManagerTest {
     void setup() {
         memberCacheManager = new MemberCacheManager();
 
-        member = Member.create("다은", "10");
+        member = Member.create("강아지", "10");
         memberId = member.getMemberId();
     }
 
@@ -31,7 +38,7 @@ class MemberCacheManagerTest {
         // then
         assertThat(cachedMember).isNotNull();
         assertThat(cachedMember.getMemberId()).isEqualTo(memberId);
-        assertThat(cachedMember.getNickname()).isEqualTo("다은");
+        assertThat(cachedMember.getNickname()).isEqualTo("강아지");
         assertThat(cachedMember.getProfile()).isEqualTo("10");
     }
 
@@ -63,8 +70,6 @@ class MemberCacheManagerTest {
     @DisplayName("캐시 전체 비우기 테스트")
     void cacheClearTest() {
         // given
-        Member member = Member.create("강아지", "23");
-        Long memberId = member.getMemberId();
         Member member2 = Member.create("고양이", "32");
         Long member2Id = member2.getMemberId();
 

--- a/server/src/test/java/com/codecozy/server/cache/MemberCacheManagerTest.java
+++ b/server/src/test/java/com/codecozy/server/cache/MemberCacheManagerTest.java
@@ -1,0 +1,81 @@
+package com.codecozy.server.cache;
+
+import com.codecozy.server.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberCacheManagerTest {
+
+    private MemberCacheManager memberCacheManager;
+
+    private Member member;
+    private Long memberId;
+
+    @BeforeEach
+    void setup() {
+        memberCacheManager = new MemberCacheManager();
+
+        member = Member.create("다은", "10");
+        memberId = member.getMemberId();
+    }
+
+    @Test
+    @DisplayName("캐시에 데이터 삽입 및 조회 테스트")
+    void cachePutAndGetTest() {
+        // when
+        memberCacheManager.put(memberId, member);
+        Member cachedMember = memberCacheManager.get(memberId);
+
+        // then
+        assertThat(cachedMember).isNotNull();
+        assertThat(cachedMember.getMemberId()).isEqualTo(memberId);
+        assertThat(cachedMember.getNickname()).isEqualTo("다은");
+        assertThat(cachedMember.getProfile()).isEqualTo("10");
+    }
+
+    @Test
+    @DisplayName("캐시에 존재하지 않는 데이터 조회")
+    void cacheNotExistTest() {
+        // when
+        Member member = memberCacheManager.get(100L);
+
+        // then
+        assertThat(member).isNull();
+    }
+
+    @Test
+    @DisplayName("캐시 데이터 삭제 테스트")
+    void cacheRemoveTest() {
+        // given
+        memberCacheManager.put(memberId, member);
+
+        // when
+        memberCacheManager.remove(memberId);
+        Member cachedMember = memberCacheManager.get(memberId);
+
+        // then
+        assertThat(cachedMember).isNull();
+    }
+
+    @Test
+    @DisplayName("캐시 전체 비우기 테스트")
+    void cacheClearTest() {
+        // given
+        Member member = Member.create("강아지", "23");
+        Long memberId = member.getMemberId();
+        Member member2 = Member.create("고양이", "32");
+        Long member2Id = member2.getMemberId();
+
+        memberCacheManager.put(memberId, member);
+        memberCacheManager.put(member2Id, member2);
+
+        // when
+        memberCacheManager.clearCache();
+
+        // then
+        assertThat(memberCacheManager.get(memberId)).isNull();
+        assertThat(memberCacheManager.get(member2Id)).isNull();
+    }
+}


### PR DESCRIPTION
## 목적🎯
원활한 캐시 사용 및 관리를 위해 캐시 매니저 구현

## 변경사항🛠️
 - Member 캐시를 관리하는 캐시 매니저 추가
 - Member 객체를 캐시로 사용하는 Service 로직에 캐시 적용

## 수행한 테스트✏️
 - 캐시 매니저 기능 테스트(캐시 데이터 삽입, 조회, 삭제, 전체 삭제 테스트)
 - 테스트에서 캐시 사용이 원활하도록 통합 테스트로 변경
 - Member 객체를 캐시로 사용하는 Service 로직에서 로그와 디버깅을 통해 실제 캐시값이 사용되는지 확인

## 비고📌
저번에 말씀주신 레포지토리 접근 횟수 확인 테스트를 구현해보려고 했는데 memberService에서는 예시 토큰 값을 직접 매개변수로 입력하지 않으면 토큰 인증 과정에서 오류가 나더라구요..! 그래서 다른 Service에서 테스트를 진행하려 했는데, 캐시는 통합 테스트 환경에서 원활하게 체크할 수 있다고 해서 통합 테스트 설정을 하다보니 메서드 호출 횟수를 검증하는 verify는 통합 테스트에서 쓰기 어렵다 하더라구요..🥲 그래서 일단 실제 코드를 돌려보면서 캐시 매니저에 캐시가 잘 사용되는지 확인하고 메서드 호출 횟수 검증 테스트 코드는 (구현이 가능하다면...) 분리해서 진행해보려고 합니다..!!