### PR TITLE
뱃지 획득 기능 구현

### DIFF
--- a/server/src/main/java/com/codecozy/server/annotation/TrackBadgeActivity.java
+++ b/server/src/main/java/com/codecozy/server/annotation/TrackBadgeActivity.java
@@ -1,0 +1,17 @@
+package com.codecozy.server.annotation;
+
+import com.codecozy.server.context.BadgeActionType;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 뱃지 획득 조건을 추적하기 위해 사용하는 어노테이션
+ * - action type 종류는 BadgeActionType 내 주석 참고
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackBadgeActivity {
+    BadgeActionType[] actionType();
+}

--- a/server/src/main/java/com/codecozy/server/aspect/UserActivityAspect.java
+++ b/server/src/main/java/com/codecozy/server/aspect/UserActivityAspect.java
@@ -1,0 +1,34 @@
+package com.codecozy.server.aspect;
+
+import com.codecozy.server.annotation.TrackBadgeActivity;
+import com.codecozy.server.dto.etc.BadgeEvent;
+import com.codecozy.server.dto.etc.CustomUserDetails;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+// 유저 활동을 추적하기 위한 aspect
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class UserActivityAspect {
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 뱃지 획득 검증 이벤트를 발행하기 위한 메소드
+    @AfterReturning("@annotation(badgeActivity)")
+    private void trackBadgeActivity(TrackBadgeActivity badgeActivity) {
+        CustomUserDetails details = (CustomUserDetails) SecurityContextHolder.getContext()
+                                                                             .getAuthentication()
+                                                                             .getPrincipal();
+
+        eventPublisher.publishEvent(new BadgeEvent(
+                Long.parseLong(details.getUsername()),
+                badgeActivity.actionType(),
+                LocalDate.now()
+        ));
+    }
+}

--- a/server/src/main/java/com/codecozy/server/context/BadgeActionType.java
+++ b/server/src/main/java/com/codecozy/server/context/BadgeActionType.java
@@ -1,0 +1,16 @@
+package com.codecozy.server.context;
+
+// 뱃지 획득 조건 검사를 위한 action type
+public enum BadgeActionType {
+    // 서재에 책을 등록할 때 (읽는 중 & 다 읽음)
+    CREATE_BOOK,
+
+    // 독서 진행률을 변경할 때 or 다 읽음 표시를 할 때
+    UPDATE_READING,
+
+    // 책갈피, 인물사전, 메모를 등록할 때
+    CREATE_RECORD,
+
+    // 키워드 리뷰, 선택 리뷰, 한줄평 리뷰를 등록할 때
+    CREATE_REVIEW
+}

--- a/server/src/main/java/com/codecozy/server/context/ReadingStatus.java
+++ b/server/src/main/java/com/codecozy/server/context/ReadingStatus.java
@@ -1,0 +1,9 @@
+package com.codecozy.server.context;
+
+// 독서상태 값 모음
+public class ReadingStatus {
+    public static final int UNREGISTERED = -1;    // 미등록
+    public static final int WANT_TO_READ = 0;     // 읽고 싶은
+    public static final int READING = 1;          // 읽는 중
+    public static final int FINISH_READ = 2;      // 다 읽음
+}

--- a/server/src/main/java/com/codecozy/server/controller/BookController.java
+++ b/server/src/main/java/com/codecozy/server/controller/BookController.java
@@ -1,5 +1,7 @@
 package com.codecozy.server.controller;
 
+import com.codecozy.server.annotation.TrackBadgeActivity;
+import com.codecozy.server.context.BadgeActionType;
 import com.codecozy.server.dto.request.*;
 import com.codecozy.server.security.TokenProvider;
 import com.codecozy.server.service.BookService;
@@ -20,6 +22,7 @@ public class BookController {
 
     // 책 등록 API
     @PostMapping("/{isbn}")
+    @TrackBadgeActivity(actionType = BadgeActionType.CREATE_BOOK)
     public ResponseEntity createBook(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                      @RequestBody ReadingBookCreateRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -45,6 +48,7 @@ public class BookController {
 
     // 독서상태 변경 API
     @PatchMapping("/{isbn}/reading-status")
+    @TrackBadgeActivity(actionType = BadgeActionType.CREATE_BOOK)
     public ResponseEntity modifyReadingStatus(@RequestHeader("xAuthToken") String token,
                                               @PathVariable("isbn") String isbn,
                                               @RequestBody ModifyReadingStatusRequest request) {
@@ -81,6 +85,7 @@ public class BookController {
 
     // 리뷰 작성 API
     @PostMapping("/{isbn}/review")
+    @TrackBadgeActivity(actionType = BadgeActionType.CREATE_REVIEW)
     public ResponseEntity createReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                        @RequestBody ReviewCreateRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -90,6 +95,7 @@ public class BookController {
 
     // 리뷰 전체 수정 API
     @PatchMapping("/{isbn}/review")
+    @TrackBadgeActivity(actionType = BadgeActionType.CREATE_REVIEW)
     public ResponseEntity modifyReview(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                        @RequestBody ReviewCreateRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -217,6 +223,7 @@ public class BookController {
 
     // 인물사전 등록 API
     @PostMapping("/{isbn}/character-dictionary")
+    @TrackBadgeActivity(actionType = BadgeActionType.CREATE_RECORD)
     public ResponseEntity addPersonalDictionary(@RequestHeader("xAuthToken") String token,
                                                 @PathVariable("isbn") String isbn,
                                                 @RequestBody PersonalDictionaryRequest request) {
@@ -256,6 +263,7 @@ public class BookController {
 
     // 메모 등록 API
     @PostMapping("/{isbn}/memo")
+    @TrackBadgeActivity(actionType = BadgeActionType.CREATE_RECORD)
     public ResponseEntity addMemo(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                   @RequestBody MemoRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -291,6 +299,7 @@ public class BookController {
 
     // 책갈피 등록 API
     @PostMapping("/{isbn}/bookmark")
+    @TrackBadgeActivity(actionType = {BadgeActionType.CREATE_RECORD, BadgeActionType.UPDATE_READING})
     public ResponseEntity addBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                       @RequestBody BookmarkRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);
@@ -300,6 +309,7 @@ public class BookController {
 
     // 책갈피 수정 API
     @PatchMapping("/{isbn}/bookmark")
+    @TrackBadgeActivity(actionType = BadgeActionType.UPDATE_READING)
     public ResponseEntity modifyBookmark(@RequestHeader("xAuthToken") String token, @PathVariable("isbn") String isbn,
                                          @RequestBody BookmarkRequest request) {
         Long memberId = tokenProvider.getMemberIdFromToken(token);

--- a/server/src/main/java/com/codecozy/server/dto/etc/BadgeEvent.java
+++ b/server/src/main/java/com/codecozy/server/dto/etc/BadgeEvent.java
@@ -1,0 +1,11 @@
+package com.codecozy.server.dto.etc;
+
+import com.codecozy.server.context.BadgeActionType;
+import java.time.LocalDate;
+
+// 뱃지 획득 조건 검사 이벤트
+public record BadgeEvent(
+        Long memberId,
+        BadgeActionType[] actionType,
+        LocalDate date
+) {}

--- a/server/src/main/java/com/codecozy/server/dto/etc/CreateBookAction.java
+++ b/server/src/main/java/com/codecozy/server/dto/etc/CreateBookAction.java
@@ -1,0 +1,9 @@
+package com.codecozy.server.dto.etc;
+
+import com.codecozy.server.entity.Book;
+
+// 뱃지 검사 시 사용
+public record CreateBookAction(
+        int readingStatus,
+        Book book
+) {}

--- a/server/src/main/java/com/codecozy/server/dto/etc/CustomUserDetails.java
+++ b/server/src/main/java/com/codecozy/server/dto/etc/CustomUserDetails.java
@@ -1,4 +1,4 @@
-package com.codecozy.server.dto;
+package com.codecozy.server.dto.etc;
 
 import java.util.Collection;
 import lombok.AllArgsConstructor;

--- a/server/src/main/java/com/codecozy/server/dto/etc/NoteWithReview.java
+++ b/server/src/main/java/com/codecozy/server/dto/etc/NoteWithReview.java
@@ -1,0 +1,11 @@
+package com.codecozy.server.dto.etc;
+
+import com.codecozy.server.entity.BookReview;
+import com.codecozy.server.entity.SelectReview;
+
+// 리뷰 관련 뱃지 검사 시 사용
+public record NoteWithReview(
+        String keyword,
+        SelectReview selectReview,
+        BookReview bookReview
+) {}

--- a/server/src/main/java/com/codecozy/server/entity/Badge.java
+++ b/server/src/main/java/com/codecozy/server/entity/Badge.java
@@ -3,10 +3,16 @@ package com.codecozy.server.entity;
 import com.codecozy.server.composite_key.BadgeKey;
 import jakarta.persistence.*;
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @IdClass(BadgeKey.class)
 @Table(name = "BADGE")
 public class Badge {
@@ -21,5 +27,13 @@ public class Badge {
 
     @Column(nullable = false)
     private LocalDate date;
+
+    public static Badge create(Member member, int badgeCode, LocalDate date) {
+        return Badge.builder()
+                    .member(member)
+                    .badgeCode(badgeCode)
+                    .date(date)
+                    .build();
+    }
 }
 

--- a/server/src/main/java/com/codecozy/server/entity/BookRecord.java
+++ b/server/src/main/java/com/codecozy/server/entity/BookRecord.java
@@ -64,8 +64,8 @@ public class BookRecord {
     @Column(name = "mark_page", nullable = false)
     private int markPage;
 
-    @Column(name = "key_word", length = 15)
-    private String keyWord;
+    @Column(name = "keyword", length = 15)
+    private String keyword;
 
     @OneToOne(mappedBy = "bookRecord", cascade = CascadeType.REMOVE)
     private BookReview bookReview;
@@ -92,7 +92,7 @@ public class BookRecord {
 
     public void setMarkPage(int markPage) { this.markPage = markPage; }
 
-    public void setKeyWord(String keyWord) { this.keyWord = keyWord; }
+    public void setKeyword(String keyword) { this.keyword = keyword; }
 
     public void setLocationInfo(LocationInfo locationInfo) { this.locationInfo = locationInfo; }
 

--- a/server/src/main/java/com/codecozy/server/listener/ActivityEventListener.java
+++ b/server/src/main/java/com/codecozy/server/listener/ActivityEventListener.java
@@ -1,0 +1,26 @@
+package com.codecozy.server.listener;
+
+import com.codecozy.server.dto.etc.BadgeEvent;
+import com.codecozy.server.service.BadgeService;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ActivityEventListener {
+    private final BadgeService badgeService;
+
+    @EventListener
+    public void handleBadgeActivity(BadgeEvent event) {
+        // 비동기로 뱃지 조건 검증 수행
+        CompletableFuture.runAsync(() -> {
+            badgeService.verifyBadgeActivity(event);
+        }).exceptionally(ex -> {
+            // Exception 발생 시 콘솔에 출력하도록 함
+            ex.printStackTrace();
+            return null;
+        });
+    }
+}

--- a/server/src/main/java/com/codecozy/server/repository/BookRecordRepository.java
+++ b/server/src/main/java/com/codecozy/server/repository/BookRecordRepository.java
@@ -1,12 +1,13 @@
 package com.codecozy.server.repository;
 
 import com.codecozy.server.composite_key.BookRecordKey;
+import com.codecozy.server.dto.etc.CreateBookAction;
+import com.codecozy.server.dto.etc.NoteWithReview;
 import com.codecozy.server.entity.Book;
 import com.codecozy.server.entity.BookRecord;
 import com.codecozy.server.entity.LocationInfo;
 import com.codecozy.server.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,6 +21,19 @@ public interface BookRecordRepository extends JpaRepository<BookRecord, BookReco
 
     // 특정 유저의 특정 독서 상태의 독서 노트 중, 10개만 가져오기
     List<BookRecord> findTop10ByMemberAndReadingStatusOrderByCreateDateDesc(Member member, int readingStatus);
+
+    // (뱃지 검사용) 특정 유저의 몇몇 독서 상태를 갖고 있는 독서 노트를 모두 가져오기
+    List<CreateBookAction> findAllByMemberAndReadingStatusIn(Member member, List<Integer> readingStatusList);
+
+    // (뱃지 검사용) 특정 유저의 몇몇 독서 상태를 갖고 있고, 리뷰가 하나라도 등록된 독서노트들 모두 가져오기
+    @Query("SELECT new com.codecozy.server.dto.etc.NoteWithReview(b.keyword, b.selectReview, b.bookReview)"
+            + " FROM BookRecord b"
+            + " LEFT JOIN b.selectReview sr"
+            + " LEFT JOIN b.bookReview br"
+            + " WHERE b.member = :member AND b.readingStatus IN :readingStatusList"
+            + " AND (b.keyword IS NOT NULL OR sr IS NOT NULL OR br IS NOT NULL)")
+    List<NoteWithReview> getBookRecordWithReviews(@Param("member") Member member,
+                                                  @Param("readingStatusList") List<Integer> readingStatusList);
 
     // 특정 유저의 특정 독서 상태, 특정 숨김 여부를 갖고 있는 모든 독서 노트 가져오기
     List<BookRecord> findAllByMemberAndReadingStatusAndIsHidden(Member member, int readingStatus, boolean isHidden);

--- a/server/src/main/java/com/codecozy/server/repository/MemoRepository.java
+++ b/server/src/main/java/com/codecozy/server/repository/MemoRepository.java
@@ -2,6 +2,7 @@ package com.codecozy.server.repository;
 
 import com.codecozy.server.composite_key.MemoKey;
 import com.codecozy.server.entity.BookRecord;
+import com.codecozy.server.entity.Member;
 import com.codecozy.server.entity.Memo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -16,4 +17,7 @@ public interface MemoRepository extends JpaRepository<Memo, MemoKey> {
 
     // 특정 독서노트 내에 작성된 최근 3개의 메모 가져오기
     List<Memo> findTop3ByBookRecordOrderByDateDesc(BookRecord bookRecord);
+
+    // (뱃지 검사용) 특정 유저의 메모 작성 여부 가져오기
+    boolean existsByBookRecordMember(Member member);
 }

--- a/server/src/main/java/com/codecozy/server/repository/PersonalDictionaryRepository.java
+++ b/server/src/main/java/com/codecozy/server/repository/PersonalDictionaryRepository.java
@@ -2,6 +2,7 @@ package com.codecozy.server.repository;
 
 import com.codecozy.server.composite_key.PersonalDictionaryKey;
 import com.codecozy.server.entity.BookRecord;
+import com.codecozy.server.entity.Member;
 import com.codecozy.server.entity.PersonalDictionary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -16,4 +17,7 @@ public interface PersonalDictionaryRepository extends JpaRepository<PersonalDict
 
     // 특정 독서노트 내의 이름순 3개 인물사전 가져오기
     List<PersonalDictionary> findTop3ByBookRecordOrderByNameAsc(BookRecord bookRecord);
+
+    // (뱃지 검사용) 특정 유저의 모든 인물사전 가져오기
+    List<PersonalDictionary> findAllByBookRecordMember(Member member);
 }

--- a/server/src/main/java/com/codecozy/server/service/BadgeService.java
+++ b/server/src/main/java/com/codecozy/server/service/BadgeService.java
@@ -1,6 +1,7 @@
 package com.codecozy.server.service;
 
 import com.codecozy.server.context.BadgeActionType;
+import com.codecozy.server.context.ReadingStatus;
 import com.codecozy.server.dto.etc.BadgeEvent;
 import com.codecozy.server.dto.etc.CreateBookAction;
 import com.codecozy.server.dto.etc.NoteWithReview;
@@ -8,7 +9,6 @@ import com.codecozy.server.entity.Badge;
 import com.codecozy.server.entity.Book;
 import com.codecozy.server.entity.Bookmark;
 import com.codecozy.server.entity.Member;
-import com.codecozy.server.entity.Memo;
 import com.codecozy.server.entity.PersonalDictionary;
 import com.codecozy.server.repository.BadgeRepository;
 import com.codecozy.server.repository.BookRecordRepository;
@@ -36,12 +36,6 @@ public class BadgeService {
     private final MemoRepository memoRepository;
 
     private final ConverterService converterService;
-
-    // 독서상태 값 모음
-    private static final int UNREGISTERED = -1;    // 미등록
-    private static final int WANT_TO_READ = 0;     // 읽고 싶은
-    private static final int READING = 1;          // 읽는 중
-    private static final int FINISH_READ = 2;      // 다 읽음
 
     // 뱃지 코드 모음
 //    private static final int BOOK_COUNT_CODE = 0;
@@ -74,7 +68,7 @@ public class BadgeService {
                 case CREATE_BOOK -> {
                     log.info("CREATE_BOOK 검사");
                     // 읽는중, 다읽음 상태의 독서노트 모두 가져오기
-                    List<Integer> readingStatusList = List.of(READING, FINISH_READ);
+                    List<Integer> readingStatusList = List.of(ReadingStatus.READING, ReadingStatus.FINISH_READ);
                     List<CreateBookAction> nowBookList = bookRecordRepository.findAllByMemberAndReadingStatusIn(
                             member, readingStatusList);
 
@@ -94,7 +88,8 @@ public class BadgeService {
 
                     // 2. '완독가' 뱃지 검사
                     bookCount = nowBookList.stream()
-                                           .filter(bookRecord -> bookRecord.readingStatus() == FINISH_READ)
+                                           .filter(bookRecord ->
+                                                   bookRecord.readingStatus() == ReadingStatus.FINISH_READ)
                                            .toList().size();
                     for (int index = 0; index < FINISHER_COUNT_ARR.length; index++) {
                         if (FINISHER_COUNT_ARR[index] <= bookCount) {
@@ -137,12 +132,13 @@ public class BadgeService {
                 case UPDATE_READING -> {
                     log.info("UPDATE_READING 검사");
                     // 읽는중, 다읽음 상태의 독서노트 모두 가져오기
-                    List<Integer> readingStatusList = List.of(READING, FINISH_READ);
+                    List<Integer> readingStatusList = List.of(ReadingStatus.READING, ReadingStatus.FINISH_READ);
                     List<CreateBookAction> nowBookList = bookRecordRepository.findAllByMemberAndReadingStatusIn(
                             member, readingStatusList);
 
                     int bookCount = nowBookList.stream()
-                                               .filter(bookRecord -> bookRecord.readingStatus() == FINISH_READ)
+                                               .filter(bookRecord ->
+                                                       bookRecord.readingStatus() == ReadingStatus.FINISH_READ)
                                                .toList().size();
                     for (int index = 0; index < FINISHER_COUNT_ARR.length; index++) {
                         if (FINISHER_COUNT_ARR[index] <= bookCount) {
@@ -198,7 +194,7 @@ public class BadgeService {
                 case CREATE_REVIEW -> {
                     log.info("CREATE_REVIEW 검사");
                     // 읽는중, 다읽음 상태의 리뷰가 하나라도 존재하는 독서노트 모두 가져오기
-                    List<Integer> readingStatusList = List.of(READING, FINISH_READ);
+                    List<Integer> readingStatusList = List.of(ReadingStatus.READING, ReadingStatus.FINISH_READ);
                     List<NoteWithReview> reviewList = bookRecordRepository.getBookRecordWithReviews(member,
                             readingStatusList);
 

--- a/server/src/main/java/com/codecozy/server/service/BadgeService.java
+++ b/server/src/main/java/com/codecozy/server/service/BadgeService.java
@@ -1,0 +1,250 @@
+package com.codecozy.server.service;
+
+import com.codecozy.server.context.BadgeActionType;
+import com.codecozy.server.dto.etc.BadgeEvent;
+import com.codecozy.server.dto.etc.CreateBookAction;
+import com.codecozy.server.dto.etc.NoteWithReview;
+import com.codecozy.server.entity.Badge;
+import com.codecozy.server.entity.Book;
+import com.codecozy.server.entity.Bookmark;
+import com.codecozy.server.entity.Member;
+import com.codecozy.server.entity.Memo;
+import com.codecozy.server.entity.PersonalDictionary;
+import com.codecozy.server.repository.BadgeRepository;
+import com.codecozy.server.repository.BookRecordRepository;
+import com.codecozy.server.repository.BookmarkRepository;
+import com.codecozy.server.repository.MemberRepository;
+import com.codecozy.server.repository.MemoRepository;
+import com.codecozy.server.repository.PersonalDictionaryRepository;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BadgeService {
+    private final BadgeRepository badgeRepository;
+    private final MemberRepository memberRepository;
+    private final BookRecordRepository bookRecordRepository;
+
+    private final BookmarkRepository bookmarkRepository;
+    private final PersonalDictionaryRepository personalDictionaryRepository;
+    private final MemoRepository memoRepository;
+
+    private final ConverterService converterService;
+
+    // 독서상태 값 모음
+    private static final int UNREGISTERED = -1;    // 미등록
+    private static final int WANT_TO_READ = 0;     // 읽고 싶은
+    private static final int READING = 1;          // 읽는 중
+    private static final int FINISH_READ = 2;      // 다 읽음
+
+    // 뱃지 코드 모음
+//    private static final int BOOK_COUNT_CODE = 0;
+    private static final int FINISHER_CODE = 10;
+    private static final int RECORD_MVP_CODE = 20;
+    private static final int REVIEW_MASTER_CODE = 30;
+    private static final int GENRE_CODE = 40;
+
+    // 뱃지 획득 기준 모음
+    // '서재에 등록한 책' 뱃지
+    private static final int[] BOOK_COUNT_ARR = new int[]{1, 10, 50, 100, 200, 500};
+    // '완독가' 뱃지
+    private static final int[] FINISHER_COUNT_ARR = new int[]{1, 10, 50, 100};
+    // '리뷰 마스터' 뱃지
+    private static final int[] REVIEW_MASTER_COUNT_ARR = new int[]{30, 100};
+
+    // 이벤트를 받아 각 액션별 뱃지 획득 조건을 검사하는 메소드
+    @Transactional
+    public void verifyBadgeActivity(BadgeEvent event) {
+        log.info("---뱃지 획득 조건 검사 시작---");
+        log.info("들어온 이벤트: " + Arrays.toString(event.actionType()));
+        Member member = memberRepository.findByMemberId(event.memberId());
+        List<Integer> acquiredBadgeList = member.getBadges().stream()
+                                                .map(Badge::getBadgeCode)
+                                                .toList();
+
+        for (BadgeActionType actionType : event.actionType()) {
+            switch (actionType) {
+                // 서재에 등록한 책, 완독가, 장르 애호가
+                case CREATE_BOOK -> {
+                    log.info("CREATE_BOOK 검사");
+                    // 읽는중, 다읽음 상태의 독서노트 모두 가져오기
+                    List<Integer> readingStatusList = List.of(READING, FINISH_READ);
+                    List<CreateBookAction> nowBookList = bookRecordRepository.findAllByMemberAndReadingStatusIn(
+                            member, readingStatusList);
+
+                    // 1. '서재에 등록한 책' 뱃지 검사
+                    int bookCount = nowBookList.size();
+                    for (int code = 0; code < BOOK_COUNT_ARR.length; code++) {
+                        if (BOOK_COUNT_ARR[code] <= bookCount) {
+                            // 뱃지를 획득하지 않은 상태라면 뱃지 획득 수행
+                            if (!acquiredBadgeList.contains(code)) {
+                                badgeRepository.save(Badge.create(member, code, event.date()));
+                            }
+                        } else {
+                            // 획득 조건을 못 넘었다면 중단
+                            break;
+                        }
+                    }
+
+                    // 2. '완독가' 뱃지 검사
+                    bookCount = nowBookList.stream()
+                                           .filter(bookRecord -> bookRecord.readingStatus() == FINISH_READ)
+                                           .toList().size();
+                    for (int index = 0; index < FINISHER_COUNT_ARR.length; index++) {
+                        if (FINISHER_COUNT_ARR[index] <= bookCount) {
+                            // 뱃지 코드 조합
+                            int code = index + FINISHER_CODE;
+
+                            // 뱃지를 획득하지 않은 상태라면 뱃지 획득 수행
+                            if (!acquiredBadgeList.contains(code)) {
+                                badgeRepository.save(Badge.create(member, code, event.date()));
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+
+                    // 3. '장르 애호가' 뱃지 검사
+                    // TODO: 추후 테스트 필요
+                    List<String> nowCategoryList = nowBookList.stream()
+                                                              .map(CreateBookAction::book)
+                                                              .map(Book::getCategory)
+                                                              .distinct()
+                                                              .toList();
+                    for (String category : nowCategoryList) {
+                        int code = converterService.categoryNameToCode(category);
+
+                        // 뱃지를 획득하는 장르가 아닐 경우 넘김
+                        if (code >= 6) {
+                            continue;
+                        }
+
+                        // 이미 획득한 뱃지가 아니라면 획득 수행
+                        code += GENRE_CODE;
+                        if (!acquiredBadgeList.contains(code)) {
+                            badgeRepository.save(Badge.create(member, code, event.date()));
+                        }
+                    }
+                }
+
+                // 완독가
+                case UPDATE_READING -> {
+                    log.info("UPDATE_READING 검사");
+                    // 읽는중, 다읽음 상태의 독서노트 모두 가져오기
+                    List<Integer> readingStatusList = List.of(READING, FINISH_READ);
+                    List<CreateBookAction> nowBookList = bookRecordRepository.findAllByMemberAndReadingStatusIn(
+                            member, readingStatusList);
+
+                    int bookCount = nowBookList.stream()
+                                               .filter(bookRecord -> bookRecord.readingStatus() == FINISH_READ)
+                                               .toList().size();
+                    for (int index = 0; index < FINISHER_COUNT_ARR.length; index++) {
+                        if (FINISHER_COUNT_ARR[index] <= bookCount) {
+                            // 뱃지 코드 조합
+                            int code = index + FINISHER_CODE;
+
+                            // 뱃지를 획득하지 않은 상태라면 뱃지 획득 수행
+                            if (!acquiredBadgeList.contains(code)) {
+                                badgeRepository.save(Badge.create(member, code, event.date()));
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                }
+
+                // 기록 MVP (책갈피, 인물사전, 메모)
+                case CREATE_RECORD -> {
+                    log.info("CREATE_RECORD 검사");
+                    // 책갈피, 인물사전, 메모 가져오기
+                    List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecordMember(member);
+                    List<PersonalDictionary> personalDictionaries =
+                            personalDictionaryRepository.findAllByBookRecordMember(member);
+                    boolean hasMemos = memoRepository.existsByBookRecordMember(member);
+
+                    // 1. '첫 기록' 뱃지 검사
+                    int code = RECORD_MVP_CODE;
+                    // 현재 획득한 뱃지가 아니라면 검사 수행
+                    if (!acquiredBadgeList.contains(code)) {
+                        if (bookmarks.size() > 0 && personalDictionaries.size() > 0 && hasMemos) {
+                            badgeRepository.save(Badge.create(member, code, event.date()));
+                        }
+                    }
+
+                    // 2. '두꺼운 인물사전' 뱃지 검사
+                    code++;
+                    if (!acquiredBadgeList.contains(code)) {
+                        if (personalDictionaries.size() >= 100) {
+                            badgeRepository.save(Badge.create(member, code, event.date()));
+                        }
+                    }
+
+                    // 3. '책갈피의 산' 뱃지 검사
+                    code++;
+                    if (!acquiredBadgeList.contains(code)) {
+                        if (bookmarks.size() >= 100) {
+                            badgeRepository.save(Badge.create(member, code, event.date()));
+                        }
+                    }
+                }
+
+                // 리뷰 마스터 (키워드, 선택, 한줄평)
+                case CREATE_REVIEW -> {
+                    log.info("CREATE_REVIEW 검사");
+                    // 읽는중, 다읽음 상태의 리뷰가 하나라도 존재하는 독서노트 모두 가져오기
+                    List<Integer> readingStatusList = List.of(READING, FINISH_READ);
+                    List<NoteWithReview> reviewList = bookRecordRepository.getBookRecordWithReviews(member,
+                            readingStatusList);
+
+                    // 1. '리뷰계의 라이징스타' 뱃지 검사
+                    int code = REVIEW_MASTER_CODE;
+                    if (!acquiredBadgeList.contains(code)) {
+                        // 0: 키워드
+                        // 1: 선택
+                        // 2: 한줄평
+                        Boolean[] hasReview = new Boolean[3];
+                        for (NoteWithReview review : reviewList) {
+                            if (review.keyword() != null) {
+                                hasReview[0] = true;
+                            }
+                            if (review.selectReview() != null) {
+                                hasReview[1] = true;
+                            }
+                            if (review.bookReview() != null) {
+                                hasReview[2] = true;
+                            }
+
+                            // 다 획득했다면 끝
+                            boolean isAllReview = Arrays.stream(hasReview).allMatch(r -> r);
+                            if (isAllReview) {
+                                badgeRepository.save(Badge.create(member, code, event.date()));
+                                break;
+                            }
+                        }
+                    }
+
+                    // 2. '리뷰 마스터', '리뷰 인플루언서' 뱃지 검사 (리뷰 개수 관련 뱃지)
+                    for (int count : REVIEW_MASTER_COUNT_ARR) {
+                        // 획득 조건을 넘었다면
+                        if (count <= reviewList.size()) {
+                            code++;
+                            if (!acquiredBadgeList.contains(code)) {
+                                badgeRepository.save(Badge.create(member, code, event.date()));
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        log.info("---뱃지 획득 조건 검사 끝---");
+    }
+}

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.service;
 
+import com.codecozy.server.context.ReadingStatus;
 import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.context.StatusCode;
 import com.codecozy.server.dto.request.*;
@@ -51,12 +52,6 @@ public class BookService {
     private final MemoRepository memoRepository;
     private final BookmarkRepository bookmarkRepository;
     private final ConverterService converterService;
-
-    // 독서상태 값 모음
-    private static final int UNREGISTERED = -1;    // 미등록
-    private static final int WANT_TO_READ = 0;     // 읽고 싶은
-    private static final int READING = 1;          // 읽는 중
-    private static final int FINISH_READ = 2;      // 다 읽음
 
     // 사용자가 독서노트 추가 시 실행 (책 등록, 위치 등록, 독서노트 등록, 최근 검색 위치 등록)
     public ResponseEntity<DefaultResponse> createBook(Long memberId, String isbn, ReadingBookCreateRequest request) {
@@ -284,7 +279,7 @@ public class BookService {
         int afterStatus = request.readingStatus();
 
         // 읽는 중 -> 다 읽음 전환 시
-        if (beforeStatus == READING && afterStatus == FINISH_READ) {
+        if (beforeStatus == ReadingStatus.READING && afterStatus == ReadingStatus.FINISH_READ) {
             // 1. 마지막 읽은 날짜 수정
             bookRecord.setRecentDate(LocalDate.now());
 
@@ -310,7 +305,7 @@ public class BookService {
             bookRecord.setLastEditDate(LocalDateTime.now());
         }
         // 다 읽음 -> 읽는 중 전환 시
-        else if (beforeStatus == FINISH_READ && afterStatus == READING) {
+        else if (beforeStatus == ReadingStatus.FINISH_READ && afterStatus == ReadingStatus.READING) {
             // 읽은 페이지 0으로 변경
             bookRecord.setMarkPage(0);
         }
@@ -377,7 +372,7 @@ public class BookService {
         String categoryName = response.categoryName().substring(response.categoryName().lastIndexOf(">") + 1);
 
         // readingStatus 검색
-        int readingStatus = (bookRecord != null ? bookRecord.getReadingStatus() : UNREGISTERED);
+        int readingStatus = (bookRecord != null ? bookRecord.getReadingStatus() : ReadingStatus.UNREGISTERED);
 
         // commentCount 검색
         int commentCount = bookReviewRepository.countByBookRecordBook(book);
@@ -1534,15 +1529,15 @@ public class BookService {
         bookRecord.setMarkPage(request.markPage());
         if (bookRecord.getBookType() == 0) { // 종이책인 경우
             if (request.markPage() >= book.getTotalPage()) { // 책갈피 페이지가 전체 페이지보다 같거나 크면
-                bookRecord.setReadingStatus(FINISH_READ); // 다읽음으로 수정
+                bookRecord.setReadingStatus(ReadingStatus.FINISH_READ); // 다읽음으로 수정
             } else {
-                bookRecord.setReadingStatus(READING);
+                bookRecord.setReadingStatus(ReadingStatus.READING);
             }
         } else { // 전자책, 오디오북인 경우
             if (request.markPage() >= 100) { // 100% 이상이면
-                bookRecord.setReadingStatus(FINISH_READ);
+                bookRecord.setReadingStatus(ReadingStatus.FINISH_READ);
             } else {
-                bookRecord.setReadingStatus(READING);
+                bookRecord.setReadingStatus(ReadingStatus.READING);
             }
         }
 
@@ -1928,7 +1923,7 @@ public class BookService {
                     jsonResult.get("title").toString(),
                     jsonResult.get("author").toString(),
                     jsonResult.get("categoryName").toString(),
-                    UNREGISTERED,
+                    ReadingStatus.UNREGISTERED,
                     jsonResult.get("publisher").toString(),
                     jsonResult.get("pubDate").toString(),
                     Integer.parseInt(jsonResultSub.get("itemPage").toString()),

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -159,7 +159,7 @@ public class BookService {
         int readingPercent = converterService.pageToPercent(readPage, totalPage);
         String firstReviewDate = bookRecord.getFirstReviewDate() != null ?
                 converterService.dateToString(bookRecord.getFirstReviewDate()) : null;
-        String keywordReview = bookRecord.getKeyWord();
+        String keywordReview = bookRecord.getKeyword();
         String commentReview = null;
         try {
             commentReview = bookRecord.getBookReview().getReviewText();
@@ -810,7 +810,7 @@ public class BookService {
 
         // 키워드 리뷰가 있으면 독서 노트에 수정
         if (request.keyword() != null) {
-            bookRecord.setKeyWord(request.keyword());
+            bookRecord.setKeyword(request.keyword());
             bookRecordRepository.save(bookRecord);
         }
 
@@ -890,10 +890,10 @@ public class BookService {
         // 키워드 리뷰가 있으면 독서 노트에 수정
         if (request.keyword() != null) {
             // 키워드 설정
-            bookRecord.setKeyWord(request.keyword());
+            bookRecord.setKeyword(request.keyword());
             bookRecordRepository.save(bookRecord);
         } else { // 키워드 리뷰가 없으면 null로 설정
-            bookRecord.setKeyWord(null);
+            bookRecord.setKeyword(null);
             bookRecordRepository.save(bookRecord);
         }
 
@@ -969,7 +969,7 @@ public class BookService {
 
         // 독서노트에서 키워드 삭제
         if (bookRecord != null) {
-            bookRecord.setKeyWord(null);
+            bookRecord.setKeyword(null);
             bookRecordRepository.save(bookRecord);
         } else {
             return new ResponseEntity<>(

--- a/server/src/main/java/com/codecozy/server/service/BookshelfService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookshelfService.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.service;
 
+import com.codecozy.server.context.ReadingStatus;
 import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.context.StatusCode;
 import com.codecozy.server.dto.response.DefaultResponse;
@@ -46,7 +47,7 @@ public class BookshelfService {
 
             for (BookRecord bookRecord : bookRecordList) {
                 // 읽고싶은 책은 추가X
-                if (bookRecord.getReadingStatus() == 0) {
+                if (bookRecord.getReadingStatus() == ReadingStatus.WANT_TO_READ) {
                     continue;
                 }
 
@@ -91,17 +92,17 @@ public class BookshelfService {
                 int totalPage = book.getTotalPage();
 
                 // 읽고싶은 (코드값 0)
-                if (bookRecord.getReadingStatus() == 0) {
+                if (bookRecord.getReadingStatus() == ReadingStatus.WANT_TO_READ) {
                     code0Count++;
                     code0PageList.add(totalPage);
                 }
                 // 읽는중 (코드값 1)
-                else if (bookRecord.getReadingStatus() == 1) {
+                else if (bookRecord.getReadingStatus() == ReadingStatus.READING) {
                     code1Count++;
                     code1PageList.add(totalPage);
                 }
                 // 다읽은 (코드값 2)
-                else if (bookRecord.getReadingStatus() == 2) {
+                else if (bookRecord.getReadingStatus() == ReadingStatus.FINISH_READ) {
                     code2Count++;
                     code2PageList.add(totalPage);
                 }

--- a/server/src/main/java/com/codecozy/server/service/BookshelfService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookshelfService.java
@@ -137,40 +137,9 @@ public class BookshelfService {
                 Book book = bookRecord.getBook();
                 int totalPage = book.getTotalPage();
 
-                switch (book.getCategory()) {
-                    case "인문사회" -> {
-                        countList.set(0, countList.get(0) + 1);
-                        pageList.get(0).add(totalPage);
-                    }
-                    case "문학" -> {
-                        countList.set(1, countList.get(1) + 1);
-                        pageList.get(1).add(totalPage);
-                    }
-                    case "에세이" -> {
-                        countList.set(2, countList.get(2) + 1);
-                        pageList.get(2).add(totalPage);
-                    }
-                    case "과학" -> {
-                        countList.set(3, countList.get(3) + 1);
-                        pageList.get(3).add(totalPage);
-                    }
-                    case "자기계발" -> {
-                        countList.set(4, countList.get(4) + 1);
-                        pageList.get(4).add(totalPage);
-                    }
-                    case "예술" -> {
-                        countList.set(5, countList.get(5) + 1);
-                        pageList.get(5).add(totalPage);
-                    }
-                    case "원서" -> {
-                        countList.set(6, countList.get(6) + 1);
-                        pageList.get(6).add(totalPage);
-                    }
-                    case "기타" -> {
-                        countList.set(7, countList.get(7) + 1);
-                        pageList.get(7).add(totalPage);
-                    }
-                }
+                int index = converterService.categoryNameToCode(book.getCategory());
+                countList.set(index, countList.get(index) + 1);
+                pageList.get(index).add(totalPage);
             }
 
             // dto에 정보 담기

--- a/server/src/main/java/com/codecozy/server/service/ConverterService.java
+++ b/server/src/main/java/com/codecozy/server/service/ConverterService.java
@@ -8,19 +8,19 @@ import org.springframework.stereotype.Service;
 public class ConverterService {
     // 장르 이름 -> 코드로 변경하는 메소드
     public int categoryNameToCode(String name) {
-        if (name.equals("인문사회")) {
+        if (name.equals("문학")) {
             return 0;
-        } else if (name.equals("문학")) {
-            return 1;
         } else if (name.equals("에세이")) {
+            return 1;
+        } else if (name.equals("인문사회")) {
             return 2;
         } else if (name.equals("과학")) {
             return 3;
         } else if (name.equals("자기계발")) {
             return 4;
-        } else if (name.equals("예술")) {
-            return 5;
         } else if (name.equals("원서")) {
+            return 5;
+        } else if (name.equals("예술")) {
             return 6;
         } else {  // 기타
             return 7;
@@ -30,19 +30,19 @@ public class ConverterService {
     // 장르 코드 -> 이름으로 변경하는 메소드
     public String categoryCodeToName(int code) {
         if (code == 0) {
-            return "인문사회";
-        } else if (code == 1) {
             return "문학";
-        } else if (code == 2) {
+        } else if (code == 1) {
             return "에세이";
+        } else if (code == 2) {
+            return "인문사회";
         } else if (code == 3) {
             return "과학";
         } else if (code == 4) {
             return "자기계발";
         } else if (code == 5) {
-            return "예술";
-        } else if (code == 6) {
             return "원서";
+        } else if (code == 6) {
+            return "예술";
         } else {  // 기타
             return "기타";
         }

--- a/server/src/main/java/com/codecozy/server/service/CustomUserDetailsService.java
+++ b/server/src/main/java/com/codecozy/server/service/CustomUserDetailsService.java
@@ -1,7 +1,7 @@
 package com.codecozy.server.service;
 
 import com.codecozy.server.context.ResponseMessages;
-import com.codecozy.server.dto.CustomUserDetails;
+import com.codecozy.server.dto.etc.CustomUserDetails;
 import com.codecozy.server.entity.Member;
 import com.codecozy.server.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/server/src/main/java/com/codecozy/server/service/HomeService.java
+++ b/server/src/main/java/com/codecozy/server/service/HomeService.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.service;
 
+import com.codecozy.server.context.ReadingStatus;
 import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.context.StatusCode;
 import com.codecozy.server.dto.response.DefaultResponse;
@@ -51,12 +52,6 @@ public class HomeService {
     private final BookRepository bookRepository;
     private final BookRecordRepository bookRecordRepository;
 
-    // 독서 상태 상수 값
-    private static final int UNREGISTERED = -1;    // 미등록
-    private static final int WANT_TO_READ = 0;     // 읽고 싶은
-    private static final int READING = 1;          // 읽는 중
-    private static final int FINISH_READ = 2;      // 다 읽음
-
     // 메인 화면 조회
     public ResponseEntity<DefaultResponse> getMainPage(Long memberId) {
         // 해당 유저 가져오기
@@ -66,7 +61,7 @@ public class HomeService {
         List<MainBooksResponse> booksList = new ArrayList<>();
 
         // 읽고 있는 책 리스트 가져오기 (최대 10개)
-        List<BookRecord> readingBooks = bookRecordRepository.getMainReadingBooks(member, READING);
+        List<BookRecord> readingBooks = bookRecordRepository.getMainReadingBooks(member, ReadingStatus.READING);
 
         // dto 값 넣기
         for (BookRecord bookRecord : readingBooks) {
@@ -90,7 +85,7 @@ public class HomeService {
             }
 
             booksList.add(new MainBooksResponse(
-                    READING,
+                    ReadingStatus.READING,
                     book.getIsbn(),
                     book.getCover(),
                     book.getTitle(),
@@ -105,14 +100,14 @@ public class HomeService {
 
         // 읽고 싶은 책 리스트 가져오기 (최대 10개)
         List<BookRecord> wantToReadBooks = bookRecordRepository.findTop10ByMemberAndReadingStatusOrderByCreateDateDesc(
-                member, WANT_TO_READ);
+                member, ReadingStatus.WANT_TO_READ);
 
         // dto 값 넣기
         for (BookRecord bookRecord : wantToReadBooks) {
             Book book = bookRecord.getBook();
 
             booksList.add(new MainBooksResponse(
-                    WANT_TO_READ,
+                    ReadingStatus.WANT_TO_READ,
                     book.getIsbn(),
                     book.getCover(),
                     book.getTitle(),
@@ -127,7 +122,7 @@ public class HomeService {
 
         // 다 읽은 책 리스트 가져오기 (전체)
         List<BookRecord> finishReadBooks = bookRecordRepository.findAllByMemberAndReadingStatus(
-                member, FINISH_READ);
+                member, ReadingStatus.FINISH_READ);
 
         // dto 값 넣기
         for (BookRecord bookRecord : finishReadBooks) {
@@ -147,7 +142,7 @@ public class HomeService {
             }
 
             booksList.add(new MainBooksResponse(
-                    FINISH_READ,
+                    ReadingStatus.FINISH_READ,
                     book.getIsbn(),
                     book.getCover(),
                     book.getTitle(),
@@ -163,12 +158,12 @@ public class HomeService {
         // 읽고 싶은 책 개수 계산
         List<BookRecord> tempWantToReadList = bookRecordRepository.findAllByMemberAndReadingStatus(
                 member,
-                WANT_TO_READ);
+                ReadingStatus.WANT_TO_READ);
         int wantToReadCount = tempWantToReadList.size();
 
         // 읽고 있는 책 개수 계산
         List<BookRecord> tempReadingList = bookRecordRepository.findAllByMemberAndReadingStatus(
-                member, READING);
+                member, ReadingStatus.READING);
         int readingCount = tempReadingList.size();
 
         // 응답 보내기
@@ -277,7 +272,7 @@ public class HomeService {
         // 읽고 싶은 책 목록 가져오기
         List<BookRecord> bookRecordList = bookRecordRepository.findAllByMemberAndReadingStatus(
                 member,
-                WANT_TO_READ);
+                ReadingStatus.WANT_TO_READ);
 
         // 해당 값 dto 정보 담기
         List<WantToReadResponse> wantToReadBooks = new ArrayList<>();
@@ -307,12 +302,12 @@ public class HomeService {
         // 1. 읽고 있는 책 중, 숨기지 않은 책들만 먼저 가져오기
         List<BookRecord> notHiddenBooks = bookRecordRepository.findAllByMemberAndReadingStatusAndIsHidden(
                 member,
-                READING, false);
+                ReadingStatus.READING, false);
 
         // 2. 읽고 있는 책 중, 숨긴 책들도 가져오기
         List<BookRecord> hiddenBooks = bookRecordRepository.findAllByMemberAndReadingStatusAndIsHidden(
                 member,
-                READING, true);
+                ReadingStatus.READING, true);
 
         // dto 정보 넣기
         List<ReadingResponse> readingBooks = new ArrayList<>();
@@ -340,7 +335,7 @@ public class HomeService {
 
         // 책 정보 가져오기
         List<BookRecord> bookRecordList = bookRecordRepository.findAllByMemberAndReadingStatus(
-                member, FINISH_READ);
+                member, ReadingStatus.FINISH_READ);
 
         // dto 정보 넣기
         List<FinishReadResponse> finishReadBooks = new ArrayList<>();

--- a/server/src/main/java/com/codecozy/server/service/HomeService.java
+++ b/server/src/main/java/com/codecozy/server/service/HomeService.java
@@ -79,7 +79,7 @@ public class HomeService {
             // 리뷰 유무 판단
             Boolean isWriteReview = false;
             // 1. 한 단어 리뷰
-            String keywordReview = bookRecord.getKeyWord();
+            String keywordReview = bookRecord.getKeyword();
             // 2. 선택 키워드 리뷰
             SelectReview selectReview = bookRecord.getSelectReview();
             // 3. 한줄평 리뷰
@@ -136,7 +136,7 @@ public class HomeService {
             // 리뷰 유무 판단
             Boolean isWriteReview = false;
             // 1. 한 단어 리뷰
-            String keywordReview = bookRecord.getKeyWord();
+            String keywordReview = bookRecord.getKeyword();
             // 2. 선택 키워드 리뷰
             SelectReview selectReview = bookRecord.getSelectReview();
             // 3. 한줄평 리뷰

--- a/server/src/main/java/com/codecozy/server/service/MemberService.java
+++ b/server/src/main/java/com/codecozy/server/service/MemberService.java
@@ -235,6 +235,11 @@ public class MemberService {
             BadgeResponse tempBadge = new BadgeResponse(i, false, null);
             badgeResponseList.add(tempBadge);
         }
+        // genre 관련 배지
+        for (int i = 40; i <= 45; i++) {
+            BadgeResponse tempBadge = new BadgeResponse(i, false, null);
+            badgeResponseList.add(tempBadge);
+        }
         // 배지 코드만 빼기
         List<Integer> badgeCodeList = new ArrayList<>();
         for (BadgeResponse badgeResponse : badgeResponseList) {

--- a/server/src/test/java/com/codecozy/server/repository/BookRecordRepositoryTest.java
+++ b/server/src/test/java/com/codecozy/server/repository/BookRecordRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.codecozy.server.repository;
+
+import com.codecozy.server.dto.etc.NoteWithReview;
+import com.codecozy.server.entity.Book;
+import com.codecozy.server.entity.BookRecord;
+import com.codecozy.server.entity.BookReview;
+import com.codecozy.server.entity.Member;
+import com.codecozy.server.entity.SelectReview;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class BookRecordRepositoryTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private BookRecordRepository bookRecordRepository;
+
+    private Member member;
+
+    // 독서상태 값
+    private static final int READING = 1;          // 읽는 중
+    private static final int FINISH_READ = 2;      // 다 읽음
+
+    @BeforeEach
+    void setup() {
+        // 가입 회원 세팅
+        member = testEntityManager.persist(Member.create("이름1", "01"));
+
+        // 테스트 책 세팅 (2권)
+        Book book = testEntityManager.persist(
+                Book.create(
+                        "9791190090018",
+                        "http://example.com/cover.jpg",
+                        "제목",
+                        "작가",
+                        "과학",
+                        300,
+                        "출판사",
+                        LocalDate.now()));
+        Book book2 = testEntityManager.persist(
+                Book.create(
+                        "9791190090010",
+                        "http://example.com/cover.jpg",
+                        "제목2",
+                        "작가2",
+                        "인문",
+                        200,
+                        "출판사2",
+                        LocalDate.now()));
+
+        // 독서노트 세팅
+        BookRecord bookRecord1 = BookRecord.create(member, book);
+        bookRecord1.setReadingStatus(FINISH_READ);
+        bookRecord1 = testEntityManager.persist(bookRecord1);
+
+        BookRecord bookRecord2 = BookRecord.create(member, book2);
+        bookRecord2.setReadingStatus(READING);
+        bookRecord2 = testEntityManager.persist(bookRecord2);
+
+        // 한줄평 세팅
+        testEntityManager.persist(BookReview.create(bookRecord1, "재밌음"));
+        // 선택 리뷰 생성
+        testEntityManager.persist(SelectReview.create(bookRecord1, "11"));
+        testEntityManager.persist(SelectReview.create(bookRecord2, "12"));
+
+        // 데이터베이스 동기화 및 영속성 context 초기화
+        testEntityManager.flush();
+        testEntityManager.clear();
+    }
+
+    @Test
+    @DisplayName("리뷰가 하나라도 존재하는 독서노트 가져오기")
+    void getBookRecordWithReviews() {
+        // given
+        List<Integer> readingStatusList = new ArrayList<>();
+        readingStatusList.add(READING);
+        readingStatusList.add(FINISH_READ);
+
+        // when
+        List<NoteWithReview> findList = bookRecordRepository.getBookRecordWithReviews(member, readingStatusList);
+
+        // then
+        assertThat(findList).hasSize(2);
+        assertThat(findList.get(0).keyword()).isNull();
+        assertThat(findList.get(0).bookReview().getReviewText()).isEqualTo("재밌음");
+    }
+}

--- a/server/src/test/java/com/codecozy/server/repository/MemoRepositoryTest.java
+++ b/server/src/test/java/com/codecozy/server/repository/MemoRepositoryTest.java
@@ -120,8 +120,7 @@ class MemoRepositoryTest {
     @DisplayName("특정 독서노트 내에 작성한 최근 3개의 메모를 찾는다")
     void findTop3ByBookRecordOrderByDateDesc() {
         // given
-        bookRecord = testEntityManager.find(BookRecord.class,
-                testEntityManager.getId(bookRecord));
+        bookRecord = testEntityManager.find(BookRecord.class, testEntityManager.getId(bookRecord));
 
         // 메모 2개 추가
         memoRepository.save(Memo.create(
@@ -144,5 +143,15 @@ class MemoRepositoryTest {
         assertThat(findList).hasSize(3);
         assertThat(findList).extracting(Memo::getMarkPage)
                             .containsExactly(100, 50, 10);
+    }
+
+    @Test
+    @DisplayName("특정 사용자가 메모를 작성했다면 true를 반환한다")
+    void existsByBookRecordMember() {
+        // when
+        boolean find = memoRepository.existsByBookRecordMember(member);
+
+        // then
+        assertThat(find).isEqualTo(true);
     }
 }


### PR DESCRIPTION
## 목적🎯
- 뱃지 획득 기능 구현

## 변경사항🛠️
- 요청/응답 dto가 아닌 기타 dto들은 `[etc]` 폴더 내로 이동했습니다.
- `Converter` 서비스 로직 내 장르 코드의 순서를 변경했습니다.
- `BookRecord`의 `keyWord` 칼럼을 `keyword`로 변경했습니다.
- AOP와 이벤트 기반 아키텍처를 활용해 뱃지 획득 로직을 구현했습니다.
  - 이때, 뱃지 검증 로직은 성능 저하를 방지하기 위해 비동기로 수행하도록 하였습니다.
  - 특정 API 메소드를 실행하고 난 후 뱃지 획득 여부를 검사하도록 했습니다.

## 수행한 테스트✏️
- Postman과 log를 통해 확인
  - 책 등록 시 '역사적인 첫 발걸음' 뱃지, 장르 관련 뱃지 획득 확인
- 단위 테스트 수행 (테스트 코드 작성)
  - `BookRecordRepository`
    - 세 가지의 리뷰(키워드, 선택, 한줄평) 중, 한 종류라도 리뷰가 존재하는 독서노트를 모두 가져오는 테스트
  - `MemoRepository`
    - 특정 사용자가 메모를 작성했는지에 대한 여부를 가져오는 테스트

## 비고📌
이후 로그 추적기를 만들 때도 이걸 활용하고 싶어 AOP+이벤트 기반 아키텍처로 기능을 분리해 (최대한 서로 의존적이지 않도록) 구성했습니다! 굳이......왜 이렇게까지 분리해놨을까......하는 의문을 가질 수도 있을 것 같아 적어둡니다..ㅎ.ㅎ