### PR TITLE
도서정보 초기 조회 API에서 카테고리 이름 형식에 맞게 수정

### DIFF
--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -58,6 +58,9 @@ public class BookService {
     private static final int READING = 1;          // 읽는 중
     private static final int FINISH_READ = 2;      // 다 읽음
 
+    // 카테고리 이름 리스트
+    private static final List<String> categoryNameList = List.of("문학", "에세이", "인문사회", "과학", "자기계발", "원서", "예술", "기타");
+
     // 캐시 매니저 설정(의존성 주입)
     private final MemberCacheManager cacheManager;
 
@@ -378,6 +381,7 @@ public class BookService {
 
         // categoryName 수정
         String categoryName = response.categoryName().substring(response.categoryName().lastIndexOf(">") + 1);
+        categoryName = extractCategory(categoryName);
 
         // readingStatus 검색
         int readingStatus = (bookRecord != null ? bookRecord.getReadingStatus() : UNREGISTERED);
@@ -1982,6 +1986,22 @@ public class BookService {
                 .limit(5)
                 .collect(Collectors.toList());
     }
+
+    // 카테고리 이름 수정 메소드
+    private String extractCategory(String categoryFullName) {
+        if (categoryFullName.contains("소설")) {
+            return categoryNameList.get(0);
+        }
+
+        for (String category : categoryNameList) {
+            if (categoryFullName.contains(category)) {
+                return category;
+            }
+        }
+
+        return "기타";
+    }
+
 
     // 캐시 사용을 위한 메소드
     private Member getMemberById(Long memberId) {


### PR DESCRIPTION
## 목적🎯
도서정보 초기 조회 API에서 미리 정의한 카테고리 이름과 맞지 않는 부분을 형식에 맞게 수정

## 변경사항🛠️
용어사전에서 정의한 카테고리 이름을 사용하도록 변경

## 수행한 테스트✏️
postman을 통해 카테고리 이름 출력값이 수정한대로 반영되었는지 테스트

## 비고📌
-