### PR TITLE
AWS 서버 배포 준비, MySQL로 DB 변경 및 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ replay_pid*
 
 server/src/main/resources/jwt.yml
 server/src/main/resources/aladinConfig.yml
+server/src/main/resources/db-config.yml

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -26,9 +26,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// MySQL DB
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// JWT( JsonWebToken )
 	implementation "io.jsonwebtoken:jjwt:0.9.1"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.codecozy'
-version = '0.0.3-SNAPSHOT'
+version = '0.0.5-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'

--- a/server/src/main/java/com/codecozy/server/ServerApplication.java
+++ b/server/src/main/java/com/codecozy/server/ServerApplication.java
@@ -1,5 +1,6 @@
 package com.codecozy.server;
 
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
@@ -9,8 +10,8 @@ import org.springframework.cache.annotation.EnableCaching;
 public class ServerApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		SpringApplication.run(ServerApplication.class, args);
-
 	}
 
 }

--- a/server/src/main/java/com/codecozy/server/security/SecurityConfig.java
+++ b/server/src/main/java/com/codecozy/server/security/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.codecozy.server.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -24,8 +23,7 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring()
-                           .requestMatchers(allowedUrls)    // 일부 url 허용
-                           .requestMatchers(PathRequest.toH2Console()); // h2 콘솔 사용을 위함
+                           .requestMatchers(allowedUrls);    // 일부 url 허용
     }
 
     @Bean

--- a/server/src/main/java/com/codecozy/server/service/BadgeService.java
+++ b/server/src/main/java/com/codecozy/server/service/BadgeService.java
@@ -19,13 +19,11 @@ import com.codecozy.server.repository.PersonalDictionaryRepository;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class BadgeService {
     private final BadgeRepository badgeRepository;
     private final MemberRepository memberRepository;
@@ -55,8 +53,6 @@ public class BadgeService {
     // 이벤트를 받아 각 액션별 뱃지 획득 조건을 검사하는 메소드
     @Transactional
     public void verifyBadgeActivity(BadgeEvent event) {
-        log.info("---뱃지 획득 조건 검사 시작---");
-        log.info("들어온 이벤트: " + Arrays.toString(event.actionType()));
         Member member = memberRepository.findByMemberId(event.memberId());
         List<Integer> acquiredBadgeList = member.getBadges().stream()
                                                 .map(Badge::getBadgeCode)
@@ -66,7 +62,6 @@ public class BadgeService {
             switch (actionType) {
                 // 서재에 등록한 책, 완독가, 장르 애호가
                 case CREATE_BOOK -> {
-                    log.info("CREATE_BOOK 검사");
                     // 읽는중, 다읽음 상태의 독서노트 모두 가져오기
                     List<Integer> readingStatusList = List.of(ReadingStatus.READING, ReadingStatus.FINISH_READ);
                     List<CreateBookAction> nowBookList = bookRecordRepository.findAllByMemberAndReadingStatusIn(
@@ -130,7 +125,6 @@ public class BadgeService {
 
                 // 완독가
                 case UPDATE_READING -> {
-                    log.info("UPDATE_READING 검사");
                     // 읽는중, 다읽음 상태의 독서노트 모두 가져오기
                     List<Integer> readingStatusList = List.of(ReadingStatus.READING, ReadingStatus.FINISH_READ);
                     List<CreateBookAction> nowBookList = bookRecordRepository.findAllByMemberAndReadingStatusIn(
@@ -157,7 +151,6 @@ public class BadgeService {
 
                 // 기록 MVP (책갈피, 인물사전, 메모)
                 case CREATE_RECORD -> {
-                    log.info("CREATE_RECORD 검사");
                     // 책갈피, 인물사전, 메모 가져오기
                     List<Bookmark> bookmarks = bookmarkRepository.findAllByBookRecordMember(member);
                     List<PersonalDictionary> personalDictionaries =
@@ -192,7 +185,6 @@ public class BadgeService {
 
                 // 리뷰 마스터 (키워드, 선택, 한줄평)
                 case CREATE_REVIEW -> {
-                    log.info("CREATE_REVIEW 검사");
                     // 읽는중, 다읽음 상태의 리뷰가 하나라도 존재하는 독서노트 모두 가져오기
                     List<Integer> readingStatusList = List.of(ReadingStatus.READING, ReadingStatus.FINISH_READ);
                     List<NoteWithReview> reviewList = bookRecordRepository.getBookRecordWithReviews(member,
@@ -240,7 +232,5 @@ public class BadgeService {
                 }
             }
         }
-
-        log.info("---뱃지 획득 조건 검사 끝---");
     }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,25 +1,17 @@
 spring:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+  config:
+    import: db-config.yml
 
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         default_batch_fetch_size: 100
-        dialect: org.hibernate.dialect.H2Dialect
-        format_sql: true
-        show_sql: true
 
   # 콘솔 색상 출력을 위함
   output:


### PR DESCRIPTION
## 목적🎯
- AWS에 서버를 배포하기 위함
- AWS RDS(MySQL)와 연동 작업

## 변경사항🛠️
- H2 Database 대신 MySQL을 사용하도록 변경했습니다.
- MySQL DB 관련 자격 정보들을 시크릿 파일로 분리했습니다. (이 부분 파일은 노션을 참고해주세요!)
- 테스트를 위해 출력했던 몇몇 로그를 삭제했습니다.
  - API 수행 시 더이상 sql문을 출력하지 않습니다.
  - 뱃지 획득 로직 시 작성되었던 로그를 삭제했습니다.
- 타임존이 제대로 설정되지 않던 이슈가 있어, 이를 한국 시각으로 설정했습니다.([관련커밋](https://github.com/COD3COZY/ReadingFrame-Server/commit/255a6c1deb0283dbeb8d1c576f13333766685624))

## 수행한 테스트✏️
- 카카오 회원가입, 로그인, 닉네임 중복검사 API 요청을 통해 AWS에 배포된 서버를 테스트 했습니다.
- 책 등록 API를 통해 생성된 boor_record 엔티티의 create_date 칼럼 값이 현재 시각으로 제대로 저장되는지 확인했습니다.
- 책 등록, 리뷰 작성 API를 통해 뱃지 획득이 정상적으로 이루어지는지 테스트 했습니다.