### PR TITLE
메인화면 조회 API 내 파라미터 추가

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.0'
+	id 'org.springframework.boot' version '3.2.1'
 	id 'io.spring.dependency-management' version '1.1.4'
 	id 'war'
 }

--- a/server/src/main/java/com/codecozy/server/context/BookType.java
+++ b/server/src/main/java/com/codecozy/server/context/BookType.java
@@ -1,0 +1,9 @@
+package com.codecozy.server.context;
+
+// 책 유형
+public class BookType {
+    public static final int UNKNOWN = -1;       // 읽는중, 다읽은 책이 아닌 책들
+    public static final int PAPER_BOOK = 0;     // 종이책
+    public static final int E_BOOK = 1;         // 전자책
+    public static final int AUDIO_BOOK = 2;     // 오디오북
+}

--- a/server/src/main/java/com/codecozy/server/dto/response/MainBooksResponse.java
+++ b/server/src/main/java/com/codecozy/server/dto/response/MainBooksResponse.java
@@ -10,5 +10,6 @@ public record MainBooksResponse(
         int totalPage,
         int readPage,
         Boolean isMine,
-        Boolean isWriteReview
+        Boolean isWriteReview,
+        int bookType
 ) {}

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.service;
 
+import com.codecozy.server.context.BookType;
 import com.codecozy.server.context.ReadingStatus;
 import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.context.StatusCode;
@@ -69,7 +70,7 @@ public class BookService {
 
         // memberId와 isbn을 이용해 사용자별 리뷰 등록 책이 중복되었는지 검사
         BookRecord bookRecord = bookRecordRepository.findByMemberAndBook(member, book);
-        if (bookRecord != null && bookRecord.getBookType() != -1) { // reading_status가 '읽고싶은'(0)인 경우, bookType이 -1로 생성됨
+        if (bookRecord != null && bookRecord.getBookType() != BookType.UNKNOWN) { // reading_status가 '읽고싶은'(0)인 경우, bookType이 -1로 생성됨
             return new ResponseEntity<>(
                     DefaultResponse.from(StatusCode.CONFLICT, ResponseMessages.CONFLICT_BOOK_RECORD.get()),
                     HttpStatus.CONFLICT);
@@ -1471,7 +1472,7 @@ public class BookService {
             String dateStr = converterService.dateToString(memo.getDate());
 
             // 종이책이면 페이지 -> 퍼센트 계산
-            if (bookRecord.getBookType() == 0) {
+            if (bookRecord.getBookType() == BookType.PAPER_BOOK) {
                 int percent = converterService.pageToPercent(memo.getMarkPage(), book.getTotalPage());
                 // 응답으로 보낼 내용에 더하기
                 memoList.add(
@@ -1530,7 +1531,7 @@ public class BookService {
 
         // 책갈피 페이지에 따른 읽는중, 다읽음 수정
         bookRecord.setMarkPage(request.markPage());
-        if (bookRecord.getBookType() == 0) { // 종이책인 경우
+        if (bookRecord.getBookType() == BookType.PAPER_BOOK) { // 종이책인 경우
             if (request.markPage() >= book.getTotalPage()) { // 책갈피 페이지가 전체 페이지보다 같거나 크면
                 bookRecord.setReadingStatus(ReadingStatus.FINISH_READ); // 다읽음으로 수정
             } else {
@@ -1725,7 +1726,7 @@ public class BookService {
             String dateStr = converterService.dateToString(bookmark.getDate());
 
             // 종이책이면
-            if (bookRecord.getBookType() == 0) {
+            if (bookRecord.getBookType() == BookType.PAPER_BOOK) {
                 // 페이지 -> 퍼센트 계산
                 int percent = converterService.pageToPercent(markPage, book.getTotalPage());
                 bookmarkList.add(new BookmarkResponse(dateStr, markPage, percent, location, bookmark.getUuid()));

--- a/server/src/main/java/com/codecozy/server/service/BookshelfService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookshelfService.java
@@ -1,5 +1,6 @@
 package com.codecozy.server.service;
 
+import com.codecozy.server.context.BookType;
 import com.codecozy.server.context.ReadingStatus;
 import com.codecozy.server.context.ResponseMessages;
 import com.codecozy.server.context.StatusCode;
@@ -56,17 +57,17 @@ public class BookshelfService {
                 int totalPage = book.getTotalPage();
 
                 // 종이책 (코드값 0)
-                if (bookRecord.getBookType() == 0) {
+                if (bookRecord.getBookType() == BookType.PAPER_BOOK) {
                     code0Count++;
                     code0PageList.add(totalPage);
                 }
                 // 전자책 (코드값 1)
-                else if (bookRecord.getBookType() == 1) {
+                else if (bookRecord.getBookType() == BookType.E_BOOK) {
                     code1Count++;
                     code1PageList.add(totalPage);
                 }
                 // 오디오북 (코드값 2)
-                else if (bookRecord.getBookType() == 2) {
+                else if (bookRecord.getBookType() == BookType.AUDIO_BOOK) {
                     code2Count++;
                     code2PageList.add(totalPage);
                 }

--- a/server/src/main/java/com/codecozy/server/service/HomeService.java
+++ b/server/src/main/java/com/codecozy/server/service/HomeService.java
@@ -94,7 +94,8 @@ public class HomeService {
                     totalPage,
                     readPage,
                     bookRecord.isMine(),
-                    isWriteReview
+                    isWriteReview,
+                    bookRecord.getBookType()
             ));
         }
 
@@ -116,7 +117,8 @@ public class HomeService {
                     -1,
                     -1,
                     null,
-                    null
+                    null,
+                    bookRecord.getBookType()
             ));
         }
 
@@ -151,7 +153,8 @@ public class HomeService {
                     -1,
                     -1,
                     bookRecord.isMine(),
-                    isWriteReview
+                    isWriteReview,
+                    bookRecord.getBookType()
             ));
         }
 


### PR DESCRIPTION
## 목적🎯
- 메인화면 조회 API 파라미터 추가
- 일부 코드 리팩토링

## 변경사항🛠️
- bookType(책 유형) 값들을 상수로 참조하여 관리할 수 있도록 리팩토링했습니다.
- 메인화면 조회 API -> 책 정보들을 불러올 때 bookType 값도 포함하도록 수정했습니다.
- 스프링 버전을 3.2.0 -> 3.2.1로 수정했습니다.

## 수행한 테스트✏️
- Postman을 통해 메인화면 조회 API가 정상 작동 되는 것을 확인했습니다.

## 비고📌
그 서버 로그에 계속 'Cache miss for REQUEST dispatch to~'라는 메시지가 트래킹 되고 있었는데, 검색해보니 스프링 3.2.0일 때 흔하게 나타나는 버그 같은 건가 보더라구요..!! 이전까지는 크게 오류가 나서 멈추고 이런 건 아니라 그냥 냅뒀었는데, 계속 보다보니까 거슬려서 스프링 버전을 올렸습니다.
혹시 이렇게 버전 올린대로 진행해도 괜찮을까요?