### PR TITLE
feat: 책등록 API으로 '다읽음' 책 등록 시 모두 읽음 처리 로직 추가

### DIFF
--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -107,6 +107,11 @@ public class BookService {
                 locationInfo,
                 request.isMine(), startDate, recentDate);
 
+        // 만약 '다 읽음' 책일 경우 모든 페이지를 읽음으로 처리
+        if (request.readingStatus() == ReadingStatus.FINISH_READ) {
+            bookRecord.setMarkPage(book.getTotalPage());
+        }
+
         // 독서노트에 마지막으로 수정한 날짜 저장
         bookRecord.setLastEditDate(LocalDateTime.now());
 


### PR DESCRIPTION
## 목적🎯
처음부터 책을 '다읽음' 상태로 등록하는 경우, 책장 조회에서 안 읽은 책과 동일하게 읽은 페이지가 0으로 출력되는 경우를 수정하기 위함

## 변경사항🛠️
책 등록 API에 readingStatus가 FINISH_READ인 경우 markPage를 totalPage와 같게 수정

## 수행한 테스트✏️
Postman에서 API 실행 후 값 변화 확인

## 비고📌
-