### PR TITLE
fix: 책갈피 전체 조회 오류 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "release" ]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/server/src/main/java/com/codecozy/server/dto/response/BookmarkLocationInfoDto.java
+++ b/server/src/main/java/com/codecozy/server/dto/response/BookmarkLocationInfoDto.java
@@ -1,0 +1,9 @@
+package com.codecozy.server.dto.response;
+
+// 책갈피 전체 조회 API - 위치 정보 응답을 보낼 때 사용
+public record BookmarkLocationInfoDto(
+        String placeName,
+        String address,
+        String latitude,
+        String longitude
+) { }

--- a/server/src/main/java/com/codecozy/server/dto/response/BookmarkResponse.java
+++ b/server/src/main/java/com/codecozy/server/dto/response/BookmarkResponse.java
@@ -1,11 +1,10 @@
 package com.codecozy.server.dto.response;
 
-import java.util.List;
 
 public record BookmarkResponse(
         String date,
         int markPage,
         int markPercent,
-        List<String> location,
+        BookmarkLocationInfoDto location,
         String uuid
 ) {}

--- a/server/src/main/java/com/codecozy/server/service/BookService.java
+++ b/server/src/main/java/com/codecozy/server/service/BookService.java
@@ -1705,11 +1705,15 @@ public class BookService {
         List<Bookmark> bookmarks = bookRecord.getBookmarks();
         for (Bookmark bookmark : bookmarks) {
             // 위치 List 저장
-            List<String> location = new ArrayList<>();
-            location.add(bookmark.getLocationInfo().getPlaceName());
-            location.add(bookmark.getLocationInfo().getAddress());
-            location.add(String.valueOf(bookmark.getLocationInfo().getLatitude()));
-            location.add(String.valueOf(bookmark.getLocationInfo().getLongitude()));
+            BookmarkLocationInfoDto locationDto = null;
+            LocationInfo locationInfo = bookmark.getLocationInfo();
+            if (locationInfo != null) {
+                locationDto = new BookmarkLocationInfoDto(
+                        locationInfo.getPlaceName(),
+                        locationInfo.getAddress(),
+                        String.valueOf(locationInfo.getLatitude()),
+                        String.valueOf(locationInfo.getLongitude()));
+            }
 
             // 응답에 보낼 데이터들
             int markPage = bookmark.getMarkPage();
@@ -1719,11 +1723,11 @@ public class BookService {
             if (bookRecord.getBookType() == BookType.PAPER_BOOK) {
                 // 페이지 -> 퍼센트 계산
                 int percent = converterService.pageToPercent(markPage, book.getTotalPage());
-                bookmarkList.add(new BookmarkResponse(dateStr, markPage, percent, location, bookmark.getUuid()));
+                bookmarkList.add(new BookmarkResponse(dateStr, markPage, percent, locationDto, bookmark.getUuid()));
             } else { // 전자책, 오디오북이면
                 // 퍼센트 -> 페이지 계산
                 int page = converterService.percentToPage(markPage, book.getTotalPage());
-                bookmarkList.add(new BookmarkResponse(dateStr, page, markPage, location, bookmark.getUuid()));
+                bookmarkList.add(new BookmarkResponse(dateStr, page, markPage, locationDto, bookmark.getUuid()));
             }
         }
 


### PR DESCRIPTION
## 목적🎯
- 책갈피 전체 조회 API 내 오류 수정

## 변경사항🛠️
- 책갈피 전체 조회 시 위치 정보의 null 여부를 체크하는 구문을 추가했습니다.
- 책갈피 전체 조회 response dto 내용 중, location 정보를 List<String>로 보내고 있던 것을 발견해 이를 dto 객체 방식으로 보내도록 수정했습니다.

## 수행한 테스트✏️
- 빠른 반영을 위해 Postman으로만 테스트
  - 위치정보가 있을 경우와 없을 경우 둘 다 테스트 했습니다

## 비고📌
- 작은 버그 수정이라 서버 버전은 안 바꾸어도 될 것 같아 그대로 두었습니다!